### PR TITLE
fix: send browser request headers to puller so hotlinked streams work

### DIFF
--- a/internal/cast/ffmpeg/args.go
+++ b/internal/cast/ffmpeg/args.go
@@ -27,6 +27,11 @@ type EncodeOptions struct {
 	// (Referer, User-Agent, Cookie, etc. — needed for HLS behind proxies).
 	SourceHeaders map[string]string
 
+	// SourceContentType is the MIME type of SourceURL. It selects the
+	// container-specific input flags (see containerInputArgs). Only consulted
+	// for a network source (PipeFormat empty).
+	SourceContentType string
+
 	// RWTimeoutMicros is the upstream I/O timeout in microseconds, passed to
 	// ffmpeg's -rw_timeout for HTTP(S) input. Ignored for stdin input.
 	RWTimeoutMicros int64
@@ -83,6 +88,19 @@ type EncodeOptions struct {
 // the encode starts.
 const EncodeReadrateBurstSeconds = 10
 
+// containerInputArgs returns the ffmpeg input flags a source container needs.
+// HLS (and DASH) playlists require the extension checks relaxed; those flags
+// are options on the HLS demuxer, so ffmpeg aborts a plain-file input (MP4,
+// MKV) with "Option not found" when they are present. Direct files need none.
+func containerInputArgs(contentType string) []string {
+	switch contentType {
+	case media.HLS:
+		return media.HLSInputArgs
+	default:
+		return nil
+	}
+}
+
 // EncodeArgs assembles the encode command line. No "magic" flags: every
 // argument is either part of the standard input/output setup or comes
 // straight from a field in EncodeOptions.
@@ -117,7 +135,7 @@ func EncodeArgs(opts EncodeOptions) []string {
 		if h := media.FormatHTTPHeaders(opts.SourceHeaders); h != "" {
 			args = append(args, "-headers", h)
 		}
-		args = append(args, media.HLSInputArgs...)
+		args = append(args, containerInputArgs(opts.SourceContentType)...)
 		args = append(args, "-i", opts.SourceURL.String())
 	}
 
@@ -202,9 +220,10 @@ func EncodeArgs(opts EncodeOptions) []string {
 
 // PullOptions configures the single upstream reader's command line.
 type PullOptions struct {
-	SourceURL       *url.URL
-	SourceHeaders   map[string]string
-	RWTimeoutMicros int64
+	SourceURL         *url.URL
+	SourceHeaders     map[string]string
+	SourceContentType string // MIME type of SourceURL; selects container-specific input flags
+	RWTimeoutMicros   int64
 
 	// Verbose selects -loglevel verbose (playlist/segment URLs, connection
 	// lines) instead of the default warning level.
@@ -250,7 +269,7 @@ func PullArgs(opts PullOptions) []string {
 	if h := media.FormatHTTPHeaders(opts.SourceHeaders); h != "" {
 		args = append(args, "-headers", h)
 	}
-	args = append(args, media.HLSInputArgs...)
+	args = append(args, containerInputArgs(opts.SourceContentType)...)
 	args = append(args, "-i", opts.SourceURL.String())
 
 	// Output 1: codec-copy remux to MPEG-TS on stdout → spool. mpegts is the

--- a/internal/cast/plan.go
+++ b/internal/cast/plan.go
@@ -25,6 +25,10 @@ type Plan struct {
 	// the source is HLS behind a proxy/CDN that requires them.
 	SourceHeaders map[string]string
 
+	// SourceContentType is the resolved MIME type of SourceURL. The puller
+	// applies HLS-only ffmpeg input flags solely to HLS sources.
+	SourceContentType string
+
 	// OutputContentType is the MIME type advertised to the device (e.g.
 	// "video/mp2t" for mpegts).
 	OutputContentType string
@@ -101,6 +105,7 @@ func BuildPlan(in PlanInput) Plan {
 	return Plan{
 		SourceURL:         in.SourceURL,
 		SourceHeaders:     in.SourceHeaders,
+		SourceContentType: in.SourceContentType,
 		OutputContentType: in.SourceContentType,
 	}
 }
@@ -131,6 +136,7 @@ func planDLNA(in PlanInput) Plan {
 	p := Plan{
 		SourceURL:         in.SourceURL,
 		SourceHeaders:     in.SourceHeaders,
+		SourceContentType: in.SourceContentType,
 		OutputContentType: "video/mp2t",
 		SendRate:          int64(encodedBitsPerSec * (100 + dlnaPaceHeadroomPct) / 100 / 8),
 		SendBurst:         int64(encodedBitsPerSec * dlnaPrerollSeconds / 8),
@@ -164,6 +170,7 @@ func planChromecast(in PlanInput) Plan {
 		return Plan{
 			SourceURL:         in.SourceURL,
 			SourceHeaders:     in.SourceHeaders,
+			SourceContentType: in.SourceContentType,
 			OutputContentType: in.SourceContentType,
 		}
 	}
@@ -171,14 +178,16 @@ func planChromecast(in PlanInput) Plan {
 	return Plan{
 		SourceURL:         in.SourceURL,
 		SourceHeaders:     in.SourceHeaders,
+		SourceContentType: in.SourceContentType,
 		OutputContentType: media.MP4,
 		Transcode: &ffmpeg.EncodeOptions{
-			OutputFormat:    "mp4",
-			VideoCodec:      "copy",
-			AudioCodec:      "aac",
-			AudioBitrate:    "256k",
-			AudioSampleRate: 48000,
-			AudioChannels:   2,
+			OutputFormat:      "mp4",
+			SourceContentType: in.SourceContentType,
+			VideoCodec:        "copy",
+			AudioCodec:        "aac",
+			AudioBitrate:      "256k",
+			AudioSampleRate:   48000,
+			AudioChannels:     2,
 		},
 	}
 }

--- a/internal/cast/source.go
+++ b/internal/cast/source.go
@@ -35,12 +35,13 @@ type pull struct {
 // optional PCM output is exposed as pull.pcm.
 func startPull(ctx context.Context, cfg TranscodeConfig, plan Plan, sp *spool.Spool, wantPCM bool) (*pull, error) {
 	args := ffmpeg.PullArgs(ffmpeg.PullOptions{
-		SourceURL:       plan.SourceURL,
-		SourceHeaders:   plan.SourceHeaders,
-		RWTimeoutMicros: cfg.RWTimeout.Microseconds(),
-		Verbose:         slog.Default().Enabled(ctx, slog.LevelDebug),
-		PCM:             wantPCM,
-		PCMSampleRate:   whisper.SampleRate,
+		SourceURL:         plan.SourceURL,
+		SourceHeaders:     plan.SourceHeaders,
+		SourceContentType: plan.SourceContentType,
+		RWTimeoutMicros:   cfg.RWTimeout.Microseconds(),
+		Verbose:           slog.Default().Enabled(ctx, slog.LevelDebug),
+		PCM:               wantPCM,
+		PCMSampleRate:     whisper.SampleRate,
 	})
 
 	var opts []ffmpeg.StartOption

--- a/internal/source/extract/collector.go
+++ b/internal/source/extract/collector.go
@@ -44,20 +44,22 @@ type candidate struct {
 
 // collector captures and deduplicates stream URLs from browser events.
 type collector struct {
-	ctx           context.Context
-	patterns      []*regexp.Regexp
-	maxCandidates int
-	mu            sync.Mutex
-	candidates    []candidate
-	notify        chan struct{} // closed on first capture
+	ctx            context.Context
+	patterns       []*regexp.Regexp
+	maxCandidates  int
+	mu             sync.Mutex
+	candidates     []candidate
+	requestHeaders map[network.RequestID]map[string]string // outgoing headers, keyed by request ID
+	notify         chan struct{}                           // closed on first capture
 }
 
 func newCollector(ctx context.Context, patterns []*regexp.Regexp, maxCandidates int) *collector {
 	return &collector{
-		ctx:           ctx,
-		patterns:      patterns,
-		maxCandidates: maxCandidates,
-		notify:        make(chan struct{}),
+		ctx:            ctx,
+		patterns:       patterns,
+		maxCandidates:  maxCandidates,
+		requestHeaders: make(map[network.RequestID]map[string]string),
+		notify:         make(chan struct{}),
 	}
 }
 
@@ -187,10 +189,18 @@ func (c *collector) Wait(ctx context.Context, graceAfterActions, collectionWindo
 func (c *collector) Listen(ev any) {
 	switch e := ev.(type) {
 	case *network.EventRequestWillBeSent:
-		c.Add(e.Request.URL, networkHeadersToMap(e.Request.Headers))
+		// Only requestWillBeSent carries the real outgoing headers (Referer,
+		// User-Agent, sec-ch-*). Keep them by request ID so a stream later
+		// confirmed by MIME on responseReceived is fetched with the same headers.
+		// Proxy and CDN hosts enforce hotlink protection and return 403 without
+		// the browser's Referer, and responseReceived's own RequestHeaders come
+		// back empty.
+		headers := networkHeadersToMap(e.Request.Headers)
+		c.storeHeaders(e.RequestID, headers)
+		c.Add(e.Request.URL, headers)
 
 	case *network.EventResponseReceived:
-		c.AddByMIME(e.Response.URL, e.Response.MimeType, networkHeadersToMap(responseRequestHeaders(e.Response)))
+		c.AddByMIME(e.Response.URL, e.Response.MimeType, c.loadHeaders(e.RequestID))
 
 	case *runtime.EventConsoleAPICalled:
 		for _, arg := range e.Args {
@@ -202,13 +212,19 @@ func (c *collector) Listen(ev any) {
 	}
 }
 
-// responseRequestHeaders returns the request headers from a response, falling
-// back to the response headers when RequestHeaders is not populated by Chrome.
-func responseRequestHeaders(r *network.Response) network.Headers {
-	if len(r.RequestHeaders) > 0 {
-		return r.RequestHeaders
-	}
-	return r.Headers
+// storeHeaders records the outgoing request headers for a request ID.
+func (c *collector) storeHeaders(id network.RequestID, headers map[string]string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.requestHeaders[id] = headers
+}
+
+// loadHeaders returns the outgoing request headers recorded for a request ID,
+// or nil if the request carried none.
+func (c *collector) loadHeaders(id network.RequestID) map[string]string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.requestHeaders[id]
 }
 
 func networkHeadersToMap(h network.Headers) map[string]string {

--- a/internal/source/extract/collector.go
+++ b/internal/source/extract/collector.go
@@ -91,8 +91,17 @@ func (c *collector) add(u string, headers map[string]string, mimeType string) {
 		return
 	}
 
-	if slices.ContainsFunc(c.candidates, func(cand candidate) bool { return cand.rawURL == u }) {
-		slog.DebugContext(c.ctx, "duplicate URL, skipping", "url", u)
+	if i := slices.IndexFunc(c.candidates, func(cand candidate) bool { return cand.rawURL == u }); i >= 0 {
+		// Already captured. A URL first seen in console output carries no request
+		// headers; a later network sighting of the same URL does. Upgrade so
+		// hotlink-protected hosts get the Referer/User-Agent they require instead
+		// of a header-less 403.
+		if len(c.candidates[i].headers) == 0 && len(headers) > 0 {
+			c.candidates[i].headers = headers
+			slog.DebugContext(c.ctx, "upgraded headers for captured URL", "url", u)
+		} else {
+			slog.DebugContext(c.ctx, "duplicate URL, skipping", "url", u)
+		}
 		return
 	}
 


### PR DESCRIPTION
MIME-detected streams (e.g. 1embed.cc/api/proxy) were fetched with the Cloudflare response headers instead of request headers: the response event's RequestHeaders come back empty, and the old fallback substituted the response's own headers. Those carry no Referer, so proxy/CDN hosts that enforce hotlink protection returned 403 on every probe and pull.

Record the real outgoing headers from requestWillBeSent (Referer, User-Agent, sec-ch-*) by request ID and hand them to the response handler, so a stream confirmed by MIME is fetched with the same headers the browser used.

Fixes #14