### PR TITLE
fix: clear quarantine xattr in cask postflight

### DIFF
--- a/.github/homebrew-castor.rb.tmpl
+++ b/.github/homebrew-castor.rb.tmpl
@@ -12,5 +12,11 @@ cask "castor" do
 
   binary "castor"
 
+  # The binary is unsigned, so macOS Gatekeeper quarantines it on download and
+  # refuses to run it. Strip the quarantine attribute so it works out of the box.
+  postflight do
+    system_command "/usr/bin/xattr", args: ["-cr", "#{staged_path}/castor"]
+  end
+
   zap trash: "~/.castor/config.yml"
 end


### PR DESCRIPTION
The darwin binaries are only ad-hoc signed (not Developer ID signed or notarized), so macOS Gatekeeper quarantines them on download and refuses to launch. Users had to manually run `xattr -cr` before castor would run.

Add a postflight stanza that strips the quarantine attribute from the staged binary, so `brew install --cask stupside/tap/castor` works out of the box with no manual step.

Closes #17