### PR TITLE
fix(dlna): drive AVTransport v1, v2 and v3 renderers

### DIFF
--- a/internal/device/dlna.go
+++ b/internal/device/dlna.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/huin/goupnp"
-	"github.com/huin/goupnp/dcps/av1"
 
 	"github.com/stupside/castor/internal/media"
 )
@@ -20,10 +19,24 @@ import (
 // the cast, since this negotiation now gates the copy-vs-encode decision.
 const capsTimeout = 3 * time.Second
 
+// serviceVersions are the UPnP service versions castor looks for, newest
+// first. Renderers publish whichever version their firmware implements (Philips
+// and Sony sets commonly advertise :3) and service lookup is an exact URN
+// match, so asking only for :1 misses them. UPnP requires a higher service
+// version to stay backward compatible with the actions of lower ones, and
+// castor calls only SetAVTransportURI, Play and GetProtocolInfo — all unchanged
+// since v1.
+var serviceVersions = []int{3, 2, 1}
+
 // dlnaDevice is a connected UPnP AVTransport renderer. caps is negotiated once
 // at connect (see negotiateCaps) and reported verbatim thereafter.
+//
+// transport is the generic service client rather than a version-specific
+// wrapper: the SOAP action namespace must match the service version the device
+// published, and goupnp's av1 clients hardcode the :1 URN, which a :3 service
+// can reject as an invalid action.
 type dlnaDevice struct {
-	transport *av1.AVTransport1
+	transport goupnp.ServiceClient
 	caps      media.Renderer
 }
 
@@ -85,14 +98,27 @@ func connectDLNA(ctx context.Context, info Info) (Device, error) {
 		return nil, fmt.Errorf("fetching device description: %w", err)
 	}
 
-	transports, err := av1.NewAVTransport1ClientsFromRootDevice(loc, u)
+	transport, err := findService(loc, u, "AVTransport")
 	if err != nil {
 		return nil, fmt.Errorf("creating AVTransport client: %w", err)
 	}
-	if len(transports) == 0 {
-		return nil, fmt.Errorf("no AVTransport service found on device")
+	return &dlnaDevice{transport: transport, caps: negotiateCaps(ctx, loc, u)}, nil
+}
+
+// findService returns a client for the newest version of the named service the
+// device publishes, reporting an error when it exposes none castor can drive.
+func findService(root *goupnp.RootDevice, loc *url.URL, service string) (goupnp.ServiceClient, error) {
+	for _, version := range serviceVersions {
+		urn := fmt.Sprintf("urn:schemas-upnp-org:service:%s:%d", service, version)
+		clients, err := goupnp.NewServiceClientsFromRootDevice(root, loc, urn)
+		if err != nil || len(clients) == 0 {
+			continue
+		}
+		return clients[0], nil
 	}
-	return &dlnaDevice{transport: transports[0], caps: negotiateCaps(ctx, loc, u)}, nil
+	return goupnp.ServiceClient{}, fmt.Errorf(
+		"no %s service (v1-v3) found on device %q (UDN=%q)",
+		service, root.Device.FriendlyName, root.Device.UDN)
 }
 
 // negotiateCaps asks the renderer what it accepts, over ConnectionManager
@@ -100,18 +126,21 @@ func connectDLNA(ctx context.Context, info Info) (Device, error) {
 // best-effort: any failure, or a renderer that advertises no codec we know,
 // degrades to fallbackCaps so playback still works (just conservatively).
 func negotiateCaps(ctx context.Context, loc *goupnp.RootDevice, u *url.URL) media.Renderer {
-	managers, err := av1.NewConnectionManager1ClientsFromRootDevice(loc, u)
-	if err != nil || len(managers) == 0 {
+	manager, err := findService(loc, u, "ConnectionManager")
+	if err != nil {
 		slog.WarnContext(ctx, "no ConnectionManager service; using conservative capabilities", "error", err)
 		return fallbackCaps()
 	}
 	ctx, cancel := context.WithTimeout(ctx, capsTimeout)
 	defer cancel()
-	_, sink, err := managers[0].GetProtocolInfoCtx(ctx)
-	if err != nil {
+
+	response := &struct{ Source, Sink string }{}
+	if err := manager.SOAPClient.PerformActionCtx(
+		ctx, manager.Service.ServiceType, "GetProtocolInfo", nil, response); err != nil {
 		slog.WarnContext(ctx, "GetProtocolInfo failed; using conservative capabilities", "error", err)
 		return fallbackCaps()
 	}
+	sink := response.Sink
 	caps := parseSinkProtocolInfo(sink)
 	if len(caps.Video) == 0 {
 		slog.WarnContext(ctx, "renderer advertised no known video codec; using conservative capabilities")
@@ -243,13 +272,31 @@ func (d *dlnaDevice) Play(ctx context.Context, streamURL *url.URL, contentType s
 	}
 	slog.DebugContext(ctx, "DIDL metadata", "xml", metadata)
 
-	if err := d.transport.SetAVTransportURICtx(ctx, 0, streamURL.String(), metadata); err != nil {
+	setURI := &struct {
+		InstanceID         string
+		CurrentURI         string
+		CurrentURIMetaData string
+	}{"0", streamURL.String(), metadata}
+	if err := d.action(ctx, "SetAVTransportURI", setURI); err != nil {
 		return fmt.Errorf("setting transport URI: %w", err)
 	}
-	if err := d.transport.PlayCtx(ctx, 0, "1"); err != nil {
+
+	play := &struct {
+		InstanceID string
+		Speed      string
+	}{"0", "1"}
+	if err := d.action(ctx, "Play", play); err != nil {
 		return fmt.Errorf("starting playback: %w", err)
 	}
 	return nil
+}
+
+// action performs a SOAP action against the renderer's AVTransport service,
+// namespaced to the service version the device actually published. None of the
+// actions castor calls return out arguments, so no response is unmarshalled.
+func (d *dlnaDevice) action(ctx context.Context, name string, request any) error {
+	return d.transport.SOAPClient.PerformActionCtx(
+		ctx, d.transport.Service.ServiceType, name, request, nil)
 }
 
 func (d *dlnaDevice) Close() error {

--- a/internal/device/dlna_test.go
+++ b/internal/device/dlna_test.go
@@ -10,6 +10,110 @@ import (
 	"github.com/stupside/castor/internal/media"
 )
 
+func TestFindService(t *testing.T) {
+	service := func(serviceType string) goupnp.Service {
+		return goupnp.Service{
+			ServiceType: serviceType,
+			ControlURL:  goupnp.URLField{URL: url.URL{Scheme: "http", Host: "192.0.2.10:2870", Path: "/control/" + serviceType}, Ok: true},
+		}
+	}
+	root := func(services ...goupnp.Service) *goupnp.RootDevice {
+		return &goupnp.RootDevice{Device: goupnp.Device{
+			FriendlyName: "Test Renderer",
+			UDN:          "uuid:test",
+			Services:     services,
+		}}
+	}
+	const (
+		v1 = "urn:schemas-upnp-org:service:AVTransport:1"
+		v2 = "urn:schemas-upnp-org:service:AVTransport:2"
+		v3 = "urn:schemas-upnp-org:service:AVTransport:3"
+		rc = "urn:schemas-upnp-org:service:RenderingControl:3"
+		cm = "urn:schemas-upnp-org:service:ConnectionManager:3"
+	)
+
+	tests := []struct {
+		name    string
+		root    *goupnp.RootDevice
+		service string
+		want    string
+	}{
+		{
+			name:    "version 1 service is driven as before",
+			root:    root(service(v1)),
+			service: "AVTransport",
+			want:    v1,
+		},
+		{
+			// Philips 50PUD6654/43 and similar sets publish the v3 service only.
+			name:    "version 3 only renderer is reachable",
+			root:    root(service(rc), service(cm), service(v3)),
+			service: "AVTransport",
+			want:    v3,
+		},
+		{
+			name:    "version 2 only renderer is reachable",
+			root:    root(service(v2)),
+			service: "AVTransport",
+			want:    v2,
+		},
+		{
+			name:    "newest published version wins",
+			root:    root(service(v1), service(v2), service(v3)),
+			service: "AVTransport",
+			want:    v3,
+		},
+		{
+			name: "service nested in a sub-device is found",
+			root: &goupnp.RootDevice{Device: goupnp.Device{
+				FriendlyName: "Test Renderer",
+				Devices:      []goupnp.Device{{Services: []goupnp.Service{service(v3)}}},
+			}},
+			service: "AVTransport",
+			want:    v3,
+		},
+		{
+			name:    "renderer without any AVTransport is rejected",
+			root:    root(service(rc), service(cm)),
+			service: "AVTransport",
+			want:    "",
+		},
+		{
+			// Capability negotiation is version-locked the same way: a v3-only
+			// ConnectionManager would otherwise degrade to fallbackCaps and
+			// re-encode a stream the renderer could have copied.
+			name:    "version 3 ConnectionManager is reachable for negotiation",
+			root:    root(service(rc), service(cm), service(v3)),
+			service: "ConnectionManager",
+			want:    cm,
+		},
+	}
+
+	loc := &url.URL{Scheme: "http", Host: "192.0.2.10:2870", Path: "/dmr.xml"}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := findService(tt.root, loc, tt.service)
+			if tt.want == "" {
+				if err == nil {
+					t.Fatalf("findService() error = nil, want an error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("findService() error = %v, want nil", err)
+			}
+			if got.Service.ServiceType != tt.want {
+				t.Errorf("findService() service = %q, want %q", got.Service.ServiceType, tt.want)
+			}
+			// The SOAP action namespace must match the published version, or a
+			// strict renderer rejects the call as an invalid action.
+			if got.SOAPClient == nil {
+				t.Error("findService() returned a client with no SOAPClient")
+			}
+		})
+	}
+}
+
 func TestDLNAInfo(t *testing.T) {
 	rootDevice := func(name string) *goupnp.RootDevice {
 		return &goupnp.RootDevice{Device: goupnp.Device{FriendlyName: name}}


### PR DESCRIPTION
## Problem

`connectDLNA` looked the transport service up by the exact URN `urn:schemas-upnp-org:service:AVTransport:1`, so renderers that publish a newer version could not be connected to — even though `castor scan` listed them:

```
INFO device found name=50PUD6654/43 type=dlna address=http://192.168.1.189:2870/dmr.xml
ERRO application error error="connecting to device: creating AVTransport client:
  goupnp: service \"urn:schemas-upnp-org:service:AVTransport:1\" not found within
  device \"50PUD6654/43\""
```

The gap between those two lines is version tolerance: SSDP `M-SEARCH` for `MediaRenderer:1` is answered by a `MediaRenderer:3` device, so discovery succeeds, and the exact-match failure only surfaces later when parsing the description.

The device in question, a Philips 50PUD6654/43, publishes:

```
deviceType   urn:schemas-upnp-org:device:MediaRenderer:3
serviceType  urn:schemas-upnp-org:service:RenderingControl:3
serviceType  urn:schemas-upnp-org:service:ConnectionManager:3
serviceType  urn:schemas-upnp-org:service:AVTransport:3
```

AVTransport is there — just not at v1. This should affect any renderer advertising v2 or v3.

## Fix

Look the service up across v3, v2 and v1, newest first. UPnP requires a higher service version to remain backward compatible with the actions of lower ones, and castor calls only `SetAVTransportURI` and `Play`, both unchanged since v1.

`dlnaDevice` now holds the generic `goupnp.ServiceClient` instead of `av1.AVTransport1`. That wrapper hardcodes `URN_AVTransport_1` as the SOAP action namespace in every `PerformActionCtx` call, so reusing it for a v3 service would send a mismatched `SOAPACTION` that a strict renderer can reject as an invalid action — and goupnp ships no `av2`/`av3` package to switch to. The two actions are now issued against the service type the device actually published.

## Tests

`TestFindAVTransport` covers v1-only (existing behaviour unchanged), v3-only, v2-only, newest-wins when several versions are published, a service nested in a sub-device, and a renderer exposing no AVTransport at all.

```
ok  github.com/stupside/castor/internal/device
```

## Not verified

Service *selection* is tested against in-memory device descriptions. I have not yet confirmed end-to-end playback on the v3 renderer — `go build ./...` needs the `third_party/whisper.cpp` submodule, which wasn't checked out in my working copy, so I built and vetted `./internal/device/` only. Left as a draft for that reason; happy to confirm on hardware before it's marked ready.

https://claude.ai/code/session_01SapjS1H29hRzRbzJin212o