### PR TITLE
fix: exit when the device reports playback stopped

### DIFF
--- a/internal/cast/deliver.go
+++ b/internal/cast/deliver.go
@@ -2,6 +2,7 @@ package cast
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -29,13 +30,23 @@ func runDirect(ctx context.Context, cfg Config, plan Plan, dev device.Device, lo
 	opts.SourceHeaders = plan.SourceHeaders
 	opts.RWTimeoutMicros = cfg.Transcode.RWTimeout.Microseconds()
 
-	proc, err := ffmpeg.Start(ctx, cfg.Transcode.FFmpegPath, ffmpeg.EncodeArgs(opts))
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	proc, err := ffmpeg.Start(runCtx, cfg.Transcode.FFmpegPath, ffmpeg.EncodeArgs(opts))
 	if err != nil {
 		return fmt.Errorf("starting transcode: %w", err)
 	}
-	defer finishEncoder(ctx, proc)
+	defer finishEncoder(runCtx, proc)
 
-	return serveToDevice(ctx, plan, dev, localIP, proc.Stdout, workDir)
+	err = serveToDevice(runCtx, plan, dev, localIP, proc.Stdout, workDir)
+	if errors.Is(err, errPlaybackDone) {
+		// Deliberate teardown, not a failure: cancel so finishEncoder treats
+		// the encoder's death like a Ctrl+C instead of dumping forensics.
+		cancel()
+		return nil
+	}
+	return err
 }
 
 // finishEncoder tears down the encode process: close its output, wait for
@@ -50,9 +61,16 @@ func finishEncoder(ctx context.Context, proc *ffmpeg.Process) {
 	}
 }
 
+// errPlaybackDone ends delivery when the renderer itself reports playback
+// over — the user stopped it on the device, or it finished playing there.
+// Callers treat it as a clean exit and cancel their pipeline context first,
+// so encoder teardown reads as deliberate rather than as a failure.
+var errPlaybackDone = errors.New("device reported playback done")
+
 // serveToDevice fronts stream with the replay-from-zero HTTP server, points
 // the renderer at it, and blocks until the stream has been fully produced
-// and delivered or ctx ends.
+// and delivered, the renderer reports playback over (errPlaybackDone), or
+// ctx ends.
 func serveToDevice(ctx context.Context, plan Plan, dev device.Device, localIP string, stream io.Reader, workDir string) error {
 	fmtInfo, ok := media.FormatForContentType(plan.OutputContentType)
 	if !ok {
@@ -77,5 +95,22 @@ func serveToDevice(ctx context.Context, plan Plan, dev device.Device, localIP st
 		return fmt.Errorf("starting playback: %w", err)
 	}
 	slog.InfoContext(ctx, "streaming to device, press Ctrl+C to stop")
-	return srv.Wait(ctx)
+
+	// The renderer can end the cast too: stopped on the device, or played to
+	// the end there. WaitDone cancels the delivery wait with errPlaybackDone,
+	// which is a clean exit rather than an error.
+	waitCtx, cancel := context.WithCancelCause(ctx)
+	defer cancel(nil)
+	go func() {
+		if dev.WaitDone(waitCtx) == nil {
+			cancel(errPlaybackDone)
+		}
+	}()
+
+	err = srv.Wait(waitCtx)
+	if err != nil && errors.Is(context.Cause(waitCtx), errPlaybackDone) {
+		slog.InfoContext(ctx, "device reported playback done, stopping")
+		return errPlaybackDone
+	}
+	return err
 }

--- a/internal/cast/ffmpeg/process.go
+++ b/internal/cast/ffmpeg/process.go
@@ -6,6 +6,7 @@ package ffmpeg
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -132,7 +133,8 @@ func (p *Process) LogStderrTail(ctx context.Context, msg string) {
 }
 
 // drainStderr reads stderr line-by-line, logging each at DEBUG and retaining
-// the tail for surfacing on failure.
+// the tail for surfacing on failure. ErrClosed is not worth a warning: it only
+// means Wait closed the pipe under the scanner during teardown.
 func drainStderr(ctx context.Context, r io.Reader, tail *ringTail) {
 	scanner := bufio.NewScanner(r)
 	for scanner.Scan() {
@@ -140,7 +142,7 @@ func drainStderr(ctx context.Context, r io.Reader, tail *ringTail) {
 		tail.push(line)
 		slog.DebugContext(ctx, "ffmpeg", "line", line)
 	}
-	if err := scanner.Err(); err != nil {
+	if err := scanner.Err(); err != nil && !errors.Is(err, os.ErrClosed) {
 		slog.WarnContext(ctx, "ffmpeg stderr scanner error", "error", err)
 	}
 }

--- a/internal/cast/pipeline.go
+++ b/internal/cast/pipeline.go
@@ -2,6 +2,7 @@ package cast
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -146,7 +147,14 @@ func runSpooled(parentCtx context.Context, cfg Config, plan Plan, localIP string
 		subs.follow(ctx, g, proc.Extra)
 	}
 
-	return serveToDevice(ctx, plan, d, localIP, proc.Stdout, workDir)
+	err = serveToDevice(ctx, plan, d, localIP, proc.Stdout, workDir)
+	if errors.Is(err, errPlaybackDone) {
+		// Deliberate teardown, not a failure: cancel so finishEncoder treats
+		// the encoder's death like a Ctrl+C instead of dumping forensics.
+		cancel()
+		return nil
+	}
+	return err
 }
 
 // codecPreference ranks re-encode target codecs by efficiency, most efficient

--- a/internal/device/chromecast.go
+++ b/internal/device/chromecast.go
@@ -3,13 +3,18 @@ package device
 import (
 	"cmp"
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net"
 	"net/url"
 	"strconv"
+	"sync"
+	"sync/atomic"
 
 	"github.com/vishen/go-chromecast/application"
+	castmedia "github.com/vishen/go-chromecast/cast"
+	pb "github.com/vishen/go-chromecast/cast/proto"
 	castdns "github.com/vishen/go-chromecast/dns"
 
 	"github.com/stupside/castor/internal/media"
@@ -19,6 +24,14 @@ const chromecastPort = 8009
 
 type chromecastDevice struct {
 	app *application.Application
+
+	// armed gates the media watcher: the receiver also reports the fate of
+	// whatever it played before this cast (often IDLE/FINISHED), so only
+	// events observed after our own Load may end it.
+	armed atomic.Bool
+	watch mediaWatch
+	once  sync.Once
+	done  chan struct{} // closed when the receiver reports playback over
 }
 
 var _ Device = (*chromecastDevice)(nil)
@@ -42,7 +55,10 @@ func connectChromecast(info Info) (Device, error) {
 	if err := app.Start(host, port); err != nil {
 		return nil, fmt.Errorf("connecting to chromecast: %w", err)
 	}
-	return &chromecastDevice{app: app}, nil
+
+	dev := &chromecastDevice{app: app, done: make(chan struct{})}
+	app.AddMessageFunc(dev.watchMessage)
+	return dev, nil
 }
 
 // discoverChromecast browses mDNS (_googlecast._tcp) for cast devices until
@@ -108,7 +124,71 @@ func (c *chromecastDevice) Play(_ context.Context, streamURL *url.URL, contentTy
 	if err := c.app.Load(streamURL.String(), 0, contentType, false, true, true); err != nil {
 		return fmt.Errorf("starting chromecast playback: %w", err)
 	}
+	c.armed.Store(true)
 	return nil
+}
+
+// WaitDone blocks until the receiver reports playback over or ctx ends.
+func (c *chromecastDevice) WaitDone(ctx context.Context) error {
+	select {
+	case <-c.done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// watchMessage feeds receiver events to the media watcher. The library calls
+// it from a single dispatch goroutine, so watch needs no locking.
+func (c *chromecastDevice) watchMessage(msg *pb.CastMessage) {
+	if !c.armed.Load() || msg.GetPayloadUtf8() == "" {
+		return
+	}
+	var resp castmedia.MediaStatusResponse
+	if err := json.Unmarshal([]byte(msg.GetPayloadUtf8()), &resp); err != nil {
+		return
+	}
+	if playbackOver(&c.watch, &resp) {
+		c.once.Do(func() { close(c.done) })
+	}
+}
+
+// mediaWatch decides when receiver media statuses end the cast. A terminal
+// idle reason only counts after the session has been seen active, so a stale
+// IDLE status describing what the receiver played before this cast cannot end
+// it before it starts.
+type mediaWatch struct{ active bool }
+
+// observe feeds one MEDIA_STATUS entry and reports whether playback is over:
+// the media finished, the user cancelled it, another sender interrupted it,
+// or the receiver hit an error.
+func (w *mediaWatch) observe(playerState, idleReason string) bool {
+	switch playerState {
+	case "BUFFERING", "PLAYING", "PAUSED":
+		w.active = true
+	case "IDLE":
+		switch idleReason {
+		case "FINISHED", "CANCELLED", "INTERRUPTED", "ERROR":
+			return w.active
+		}
+	}
+	return false
+}
+
+// playbackOver reports whether one receiver message ends the cast: the
+// receiver application closing, or a media status the watcher deems terminal.
+func playbackOver(w *mediaWatch, resp *castmedia.MediaStatusResponse) bool {
+	switch resp.Type {
+	case "CLOSE":
+		return true
+	case "MEDIA_STATUS":
+		over := false
+		for _, status := range resp.Status {
+			over = w.observe(status.PlayerState, status.IdleReason) || over
+		}
+		return over
+	}
+	return false
 }
 
 func (c *chromecastDevice) Close() error {

--- a/internal/device/chromecast_test.go
+++ b/internal/device/chromecast_test.go
@@ -4,8 +4,135 @@ import (
 	"net"
 	"testing"
 
+	castmedia "github.com/vishen/go-chromecast/cast"
+	pb "github.com/vishen/go-chromecast/cast/proto"
 	castdns "github.com/vishen/go-chromecast/dns"
 )
+
+func TestPlaybackOver(t *testing.T) {
+	status := func(playerState, idleReason string) castmedia.MediaStatusResponse {
+		return castmedia.MediaStatusResponse{
+			PayloadHeader: castmedia.PayloadHeader{Type: "MEDIA_STATUS"},
+			Status:        []castmedia.Media{{PlayerState: playerState, IdleReason: idleReason}},
+		}
+	}
+
+	tests := []struct {
+		name     string
+		messages []castmedia.MediaStatusResponse
+		done     bool
+	}{
+		{
+			// The receiver reports the fate of whatever it played before this
+			// cast; a stale FINISHED must not end a session that hasn't started.
+			name:     "stale idle status before playback is ignored",
+			messages: []castmedia.MediaStatusResponse{status("IDLE", "FINISHED")},
+			done:     false,
+		},
+		{
+			name: "finished after playing ends the cast",
+			messages: []castmedia.MediaStatusResponse{
+				status("BUFFERING", ""), status("PLAYING", ""), status("IDLE", "FINISHED"),
+			},
+			done: true,
+		},
+		{
+			name: "user stop on the device ends the cast",
+			messages: []castmedia.MediaStatusResponse{
+				status("PLAYING", ""), status("IDLE", "CANCELLED"),
+			},
+			done: true,
+		},
+		{
+			name: "another sender interrupting ends the cast",
+			messages: []castmedia.MediaStatusResponse{
+				status("PLAYING", ""), status("IDLE", "INTERRUPTED"),
+			},
+			done: true,
+		},
+		{
+			name: "pause keeps the cast alive",
+			messages: []castmedia.MediaStatusResponse{
+				status("PLAYING", ""), status("PAUSED", ""),
+			},
+			done: false,
+		},
+		{
+			// A load transition parks the player IDLE with no reason; only a
+			// terminal reason ends the cast.
+			name: "idle without a terminal reason keeps the cast alive",
+			messages: []castmedia.MediaStatusResponse{
+				status("PLAYING", ""), status("IDLE", ""),
+			},
+			done: false,
+		},
+		{
+			name: "receiver app closing ends the cast",
+			messages: []castmedia.MediaStatusResponse{
+				{PayloadHeader: castmedia.PayloadHeader{Type: "CLOSE"}},
+			},
+			done: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var watch mediaWatch
+			done := false
+			for _, msg := range tt.messages {
+				done = playbackOver(&watch, &msg)
+			}
+			if done != tt.done {
+				t.Errorf("playbackOver() = %v, want %v", done, tt.done)
+			}
+		})
+	}
+}
+
+func TestWatchMessage(t *testing.T) {
+	message := func(payload string) *pb.CastMessage {
+		return &pb.CastMessage{PayloadUtf8: &payload}
+	}
+	closed := func(d *chromecastDevice) bool {
+		select {
+		case <-d.done:
+			return true
+		default:
+			return false
+		}
+	}
+
+	dev := &chromecastDevice{done: make(chan struct{})}
+	stale := `{"type":"MEDIA_STATUS","status":[{"playerState":"IDLE","idleReason":"FINISHED"}]}`
+
+	// Disarmed (before Play), even a terminal status is ignored.
+	dev.watchMessage(message(stale))
+	if closed(dev) {
+		t.Fatal("terminal status before Play must not end the cast")
+	}
+
+	dev.armed.Store(true)
+
+	// Armed but never seen active: a stale terminal status is still ignored.
+	dev.watchMessage(message(stale))
+	if closed(dev) {
+		t.Fatal("terminal status before playback engages must not end the cast")
+	}
+
+	dev.watchMessage(message(`{"type":"MEDIA_STATUS","status":[{"playerState":"PLAYING"}]}`))
+	dev.watchMessage(message(`not json`)) // receiver noise is skipped, not fatal
+	if closed(dev) {
+		t.Fatal("playback in progress must not end the cast")
+	}
+
+	dev.watchMessage(message(`{"type":"MEDIA_STATUS","status":[{"playerState":"IDLE","idleReason":"CANCELLED"}]}`))
+	if !closed(dev) {
+		t.Fatal("cancel after playback must end the cast")
+	}
+
+	// A second terminal message after done is closed must not re-close (panic).
+	dev.watchMessage(message(stale))
+}
 
 func TestChromecastInfo(t *testing.T) {
 	tests := []struct {

--- a/internal/device/device.go
+++ b/internal/device/device.go
@@ -1,7 +1,8 @@
 // Package device discovers media renderers on the local network and speaks
 // their control protocols (DLNA/UPnP AVTransport, Chromecast). The Device
 // interface is deliberately small: the cast pipeline decides what to send
-// (subtitles are burned in upstream), a Device only needs to fetch and play.
+// (subtitles are burned in upstream), a Device only needs to fetch, play,
+// and report when playback ended on its side.
 package device
 
 import (
@@ -46,6 +47,12 @@ type Device interface {
 	// server must send when this renderer fetches contentType. Nil when the
 	// protocol needs none.
 	StreamHeaders(contentType string) map[string]string
+
+	// WaitDone blocks until the renderer reports that playback ended on its
+	// side — the media finished, or the user stopped it on the device —
+	// returning nil so the caller can stop streaming. It returns ctx's error
+	// when ctx ends first. Valid only after Play.
+	WaitDone(ctx context.Context) error
 
 	Close() error
 }

--- a/internal/device/dlna.go
+++ b/internal/device/dlna.go
@@ -292,11 +292,78 @@ func (d *dlnaDevice) Play(ctx context.Context, streamURL *url.URL, contentType s
 }
 
 // action performs a SOAP action against the renderer's AVTransport service,
-// namespaced to the service version the device actually published. None of the
-// actions castor calls return out arguments, so no response is unmarshalled.
+// namespaced to the service version the device actually published. The actions
+// routed through here return no out arguments, so no response is unmarshalled.
 func (d *dlnaDevice) action(ctx context.Context, name string, request any) error {
 	return d.transport.SOAPClient.PerformActionCtx(
 		ctx, d.transport.Service.ServiceType, name, request, nil)
+}
+
+// transportPollInterval is the cadence WaitDone watches the transport at; each
+// GetTransportInfo round-trip is bounded by the same duration so a hung call
+// yields to the next poll instead of stalling the watcher.
+const transportPollInterval = 2 * time.Second
+
+// transportWatch decides when polled transport states end the cast. A stop is
+// only trusted after the renderer has been seen playing: between
+// SetAVTransportURI and the first fetched byte, renderers still report
+// STOPPED, and that must not end a cast that hasn't started.
+type transportWatch struct{ played bool }
+
+// observe feeds one polled CurrentTransportState and reports whether playback
+// is over.
+func (w *transportWatch) observe(state string) bool {
+	switch state {
+	case "PLAYING", "PAUSED_PLAYBACK":
+		w.played = true
+	case "STOPPED", "NO_MEDIA_PRESENT":
+		return w.played
+	}
+	return false
+}
+
+// WaitDone polls AVTransport GetTransportInfo until the renderer reports
+// playback stopped. SOAP failures are skipped rather than surfaced: a
+// momentarily unreachable renderer is usually still playing, and ending the
+// cast on a hiccup would cut it off mid-movie.
+func (d *dlnaDevice) WaitDone(ctx context.Context) error {
+	tick := time.NewTicker(transportPollInterval)
+	defer tick.Stop()
+
+	var watch transportWatch
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-tick.C:
+		}
+
+		state, err := d.transportState(ctx)
+		if err != nil {
+			continue
+		}
+		if watch.observe(state) {
+			return nil
+		}
+	}
+}
+
+// transportState fetches the renderer's CurrentTransportState.
+func (d *dlnaDevice) transportState(ctx context.Context) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, transportPollInterval)
+	defer cancel()
+
+	request := &struct{ InstanceID string }{"0"}
+	response := &struct {
+		CurrentTransportState  string
+		CurrentTransportStatus string
+		CurrentSpeed           string
+	}{}
+	if err := d.transport.SOAPClient.PerformActionCtx(
+		ctx, d.transport.Service.ServiceType, "GetTransportInfo", request, response); err != nil {
+		return "", err
+	}
+	return response.CurrentTransportState, nil
 }
 
 func (d *dlnaDevice) Close() error {

--- a/internal/device/dlna_test.go
+++ b/internal/device/dlna_test.go
@@ -165,6 +165,60 @@ func TestDLNAInfo(t *testing.T) {
 	}
 }
 
+func TestTransportWatch(t *testing.T) {
+	tests := []struct {
+		name   string
+		states []string
+		done   bool
+	}{
+		{
+			// The window between SetAVTransportURI and the first fetched byte:
+			// the renderer still reports STOPPED while it prepares the stream.
+			name:   "stop before playback engages is ignored",
+			states: []string{"STOPPED", "TRANSITIONING", "STOPPED"},
+			done:   false,
+		},
+		{
+			name:   "steady playback keeps the cast alive",
+			states: []string{"TRANSITIONING", "PLAYING", "PLAYING"},
+			done:   false,
+		},
+		{
+			name:   "stop after playing ends the cast",
+			states: []string{"TRANSITIONING", "PLAYING", "STOPPED"},
+			done:   true,
+		},
+		{
+			name:   "no media present after playing ends the cast",
+			states: []string{"PLAYING", "NO_MEDIA_PRESENT"},
+			done:   true,
+		},
+		{
+			name:   "pause then stop ends the cast",
+			states: []string{"PLAYING", "PAUSED_PLAYBACK", "STOPPED"},
+			done:   true,
+		},
+		{
+			name:   "pause alone keeps the cast alive",
+			states: []string{"PLAYING", "PAUSED_PLAYBACK"},
+			done:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var watch transportWatch
+			done := false
+			for _, state := range tt.states {
+				done = watch.observe(state)
+			}
+			if done != tt.done {
+				t.Errorf("observe(%v) = %v, want %v", tt.states, done, tt.done)
+			}
+		})
+	}
+}
+
 func TestParseSinkProtocolInfo(t *testing.T) {
 	// A representative Samsung-style Sink: many AVC/MPEG entries, no HEVC token.
 	avcSink := "http-get:*:audio/mpeg:*," +


### PR DESCRIPTION
fix: exit when the device reports playback stopped

Castor now watches the renderer during delivery and stops streaming when
playback ends on the device side, instead of hanging until Ctrl+C.

- DLNA: poll AVTransport GetTransportInfo and treat STOPPED and
  NO_MEDIA_PRESENT as terminal, once the transport has been seen playing
  (renderers transiently report STOPPED right after Play).
- Chromecast: watch MEDIA_STATUS events (IDLE with FINISHED, CANCELLED,
  INTERRUPTED, or ERROR idle reasons) and receiver CLOSE, armed only after
  our own Load so stale statuses from a previous session are ignored.
- A device-initiated stop tears the pipeline down like Ctrl+C, so a clean
  exit no longer dumps ffmpeg forensics.

Tested manually: stopped playback from Google Home mid stream on a real
Chromecast, and sent a SOAP Stop from a simulated remote to a UPnP/DLNA
renderer. Both exit cleanly within a few seconds instead of hanging.
Also verified with go vet and go test ./... across the full repository.

Fixes #41