### PR TITLE
fix(cast): serve sources that need request headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,20 @@ sources:
 </details>
 
 <details>
+<summary><b>Cast</b>: force a local relay with <code>delivery</code></summary>
+
+Castor decides per source whether the device fetches the stream itself or Castor relays it: a source that only answers with the headers Castor captured is always relayed, since a device is handed the URL and none of those headers. A few sources look fetchable and are refused anyway, typically an HLS playlist whose segments are served under a disguised extension (`.jpg` with `image/jpeg`), which Castor reads fine but a Chromecast rejects, showing the idle Cast icon. Nothing in the stream reveals this, so `delivery: serve` is how you say it.
+
+```yaml
+cast:
+  delivery: serve   # always relay; "auto" (the default) decides per source
+```
+
+Relaying spends this machine's bandwidth and CPU on every cast, so try it as a one-off first: `CASTOR_CAST__DELIVERY=serve castor cast url <url>`. Any key works that way, e.g. `CASTOR_RESOLVER__MAX_HEIGHT=720`.
+
+</details>
+
+<details>
 <summary><b>Resolver</b>: cap resolution with <code>max_height</code></summary>
 
 Source selection and stream probing. All options have sensible defaults; you normally only set `max_height` to your TV's vertical resolution, which caps both the selected stream and the encoder output.

--- a/cmd/cmd-cast-url.go
+++ b/cmd/cmd-cast-url.go
@@ -40,7 +40,7 @@ func (a *app) castURLCommand() *cli.Command {
 			}
 
 			stream := &media.Stream{URL: urlObj, ContentType: media.DetectFromExtension(urlObj)}
-			return cast.Play(ctx, cfg.Cast(), stream)
+			return cast.Play(ctx, cfg.Playback(), stream)
 		},
 	}
 }

--- a/cmd/cmd-cast.go
+++ b/cmd/cmd-cast.go
@@ -118,5 +118,5 @@ func (a *app) handleStreams(ctx context.Context, cmd *cli.Command, streams []*me
 		return fmt.Errorf("ranking streams: %w", err)
 	}
 
-	return cast.Play(ctx, cfg.Cast(), best)
+	return cast.Play(ctx, cfg.Playback(), best)
 }

--- a/config.yaml
+++ b/config.yaml
@@ -18,6 +18,16 @@ device:
   #   Chromecast / Roku: the device IP
   # host: 192.168.0.3
 
+cast:
+  # How the device gets the bytes. On "auto" (the default) Castor hands a smart
+  # device the source URL when it can fetch it, and relays through this machine
+  # when it can't (a source that only answers with the headers Castor captured).
+  # Set "serve" to always relay: some sources look fetchable but are refused by
+  # the device anyway, typically an HLS playlist whose segments are served under
+  # a disguised extension (.jpg with image/jpeg). Relaying spends this machine's
+  # bandwidth and CPU on every cast, so it stays opt-in.
+  # delivery: serve
+
 sources:
   # Castor ships no sources of its own. You bring your own, the same way a media
   # server points at libraries you provide. Each entry is a site whose embedded

--- a/internal/cast/core/config.go
+++ b/internal/cast/core/config.go
@@ -25,6 +25,11 @@ type Config struct {
 	Transcode TranscodeConfig
 	Resolver  resolve.Config
 
+	// Delivery is the operator's say over the delivery axis, read by
+	// ResolveDelivery. Unset (the zero value) means DeliveryAuto, so a cast
+	// nobody configured is decided entirely from capabilities and the source.
+	Delivery DeliveryPreference
+
 	// Whisper is the subtitle-transcription knob NewPlan reads to choose the
 	// subtitle axis (Enable gates burn-in). Its type lives in the cgo-free
 	// subtitle package, not the whisper transcriber, so this decision core carries

--- a/internal/cast/core/plan.go
+++ b/internal/cast/core/plan.go
@@ -13,13 +13,15 @@ type DeliveryMode int
 const (
 	// DeliverPassthrough hands the device the source URL and lets it pull the
 	// bytes directly: no local ffmpeg, no served stream. Chosen only when the
-	// renderer self-fetches AND already accepts the source container, so nothing
-	// needs rewrapping.
+	// renderer self-fetches, the source needs nothing but its URL to be fetched,
+	// AND the renderer already accepts the source container, so nothing needs
+	// rewrapping.
 	DeliverPassthrough DeliveryMode = iota
 	// DeliverServe produces the stream locally (a remux or a transcode) and serves
 	// it to the device. A push-only renderer always lands here (it never
 	// self-fetches), as does a self-fetching renderer whose source container it
-	// will not take.
+	// will not take or whose source only answers to the request headers castor
+	// captured (a renderer is handed a URL, never those headers).
 	DeliverServe
 )
 

--- a/internal/cast/core/plan.go
+++ b/internal/cast/core/plan.go
@@ -4,6 +4,27 @@ import (
 	"github.com/stupside/castor/internal/media"
 )
 
+// DeliveryPreference is what the operator asks of the delivery axis, as opposed
+// to DeliveryMode, which is what the planner decided. It exists for the one case
+// castor cannot infer: a source that lies about itself (a playlist whose segments
+// are served under a disguised extension, say) is fetchable as far as castor can
+// tell, yet the renderer refuses it. No evidence distinguishes that source from a
+// well-formed one, so only the operator can say.
+//
+// Nothing else about a cast is configurable this way on purpose. Every other axis
+// is inferred from evidence castor holds (a probe, advertised capabilities), and a
+// renderer that misbehaves there is a capability-data fix, not a knob.
+type DeliveryPreference string
+
+const (
+	// DeliveryAuto leaves the decision to ResolveDelivery. It is also what an
+	// unset key means, so the zero value needs no default.
+	DeliveryAuto DeliveryPreference = "auto"
+	// DeliveryServe refuses pass-through for every cast: castor reads the source
+	// and serves the renderer a local stream, whatever the source looks like.
+	DeliveryServe DeliveryPreference = "serve"
+)
+
 // DeliveryMode is how the renderer receives the stream bytes: it either fetches
 // the source URL itself (pass-through) or castor produces a stream locally and
 // serves it. This is the first axis of a Plan; the copy-vs-encode and subtitle
@@ -72,7 +93,7 @@ type Plan struct {
 // obtains (the source URL for a network remux, the local spool for the read-once
 // spool path), which is why nothing about the encode lives on the Plan.
 func NewPlan(source *media.Stream, caps media.Renderer, cfg Config) Plan {
-	delivery := ResolveDelivery(caps, source)
+	delivery := ResolveDelivery(caps, source, cfg)
 	return Plan{
 		Delivery:          delivery,
 		Subtitle:          ResolveSubtitle(caps, cfg),

--- a/internal/cast/core/plan_test.go
+++ b/internal/cast/core/plan_test.go
@@ -41,6 +41,7 @@ func TestNewPlan(t *testing.T) {
 		caps          media.Renderer
 		sourceCT      string
 		sourceHeaders http.Header
+		preference    DeliveryPreference
 		whisper       bool
 		delivery      DeliveryMode
 		subtitle      SubtitleMode
@@ -96,6 +97,32 @@ func TestNewPlan(t *testing.T) {
 			delivery: DeliverPassthrough,
 			subtitle: SubtitleOff,
 			outputCT: "",
+		},
+		{
+			// The operator's override, for a source nothing else convicts: it needs
+			// no headers and the renderer takes the container, yet the receiver
+			// refuses it (segments served under a disguised extension). Configured
+			// serve relays it anyway.
+			name:       "configured serve overrides an otherwise pass-through cast",
+			caps:       caps(true, media.HLS, media.MP4),
+			sourceCT:   media.HLS,
+			preference: DeliveryServe,
+			whisper:    false,
+			delivery:   DeliverServe,
+			subtitle:   SubtitleOff,
+			outputCT:   media.MP4,
+		},
+		{
+			// The explicit default reads like no key at all: nothing is overridden
+			// and the pass-through rule decides.
+			name:       "configured auto leaves the decision to the rule",
+			caps:       caps(true, media.HLS, media.MP4),
+			sourceCT:   media.HLS,
+			preference: DeliveryAuto,
+			whisper:    false,
+			delivery:   DeliverPassthrough,
+			subtitle:   SubtitleOff,
+			outputCT:   "",
 		},
 		{
 			// Chromecast remux: self-fetches but rejects the source container, so
@@ -181,7 +208,7 @@ func TestNewPlan(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			source := &media.Stream{ContentType: tt.sourceCT, Headers: tt.sourceHeaders}
-			cfg := Config{Whisper: subtitle.Whisper{Enable: tt.whisper}}
+			cfg := Config{Whisper: subtitle.Whisper{Enable: tt.whisper}, Delivery: tt.preference}
 
 			plan := NewPlan(source, tt.caps, cfg)
 

--- a/internal/cast/core/plan_test.go
+++ b/internal/cast/core/plan_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"fmt"
+	"net/http"
 	"testing"
 
 	"github.com/stupside/castor/internal/cast/subtitle"
@@ -36,13 +37,14 @@ func TestNewPlan(t *testing.T) {
 	}
 
 	tests := []struct {
-		name     string
-		caps     media.Renderer
-		sourceCT string
-		whisper  bool
-		delivery DeliveryMode
-		subtitle SubtitleMode
-		outputCT string
+		name          string
+		caps          media.Renderer
+		sourceCT      string
+		sourceHeaders http.Header
+		whisper       bool
+		delivery      DeliveryMode
+		subtitle      SubtitleMode
+		outputCT      string
 	}{
 		{
 			// Chromecast direct play: self-fetches and already takes the source
@@ -65,6 +67,32 @@ func TestNewPlan(t *testing.T) {
 			caps:     caps(true, media.MP4),
 			sourceCT: media.MP4,
 			whisper:  true,
+			delivery: DeliverPassthrough,
+			subtitle: SubtitleOff,
+			outputCT: "",
+		},
+		{
+			// A source castor could only fetch with captured request headers is not
+			// passed through even when the renderer self-fetches and takes the
+			// container: the renderer is handed the URL and none of the headers, so
+			// it would fetch nothing (Cast loads the URL, then idles). Castor pulls
+			// it with the headers and serves the remux instead.
+			name:          "header-gated source serves even when the renderer accepts the container",
+			caps:          caps(true, media.HLS, media.MP4),
+			sourceCT:      media.HLS,
+			sourceHeaders: http.Header{"Referer": {"https://player.example/"}, "Origin": {"https://player.example"}},
+			whisper:       false,
+			delivery:      DeliverServe,
+			subtitle:      SubtitleOff,
+			outputCT:      media.MP4,
+		},
+		{
+			// The same source without headers is self-sufficient: a direct URL the
+			// user casts by hand still passes through, no local ffmpeg.
+			name:     "header-free source of an accepted container still passes through",
+			caps:     caps(true, media.HLS, media.MP4),
+			sourceCT: media.HLS,
+			whisper:  false,
 			delivery: DeliverPassthrough,
 			subtitle: SubtitleOff,
 			outputCT: "",
@@ -152,7 +180,7 @@ func TestNewPlan(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			source := &media.Stream{ContentType: tt.sourceCT}
+			source := &media.Stream{ContentType: tt.sourceCT, Headers: tt.sourceHeaders}
 			cfg := Config{Whisper: subtitle.Whisper{Enable: tt.whisper}}
 
 			plan := NewPlan(source, tt.caps, cfg)

--- a/internal/cast/core/resolve.go
+++ b/internal/cast/core/resolve.go
@@ -19,9 +19,16 @@ import (
 //   - the renderer already accepts the source container, so there is nothing to
 //     rewrap.
 //
-// It is decided purely from data: capabilities on one side, the source on the
-// other, no I/O and no device family.
-func ResolveDelivery(caps media.Renderer, source *media.Stream) DeliveryMode {
+// Configured DeliveryServe skips the question: it is the operator's answer for a
+// source none of the evidence above can convict (see DeliveryPreference). Every
+// other value, including the unset one, leaves the decision here.
+//
+// It is otherwise decided purely from data: capabilities on one side, the source
+// on the other, no I/O and no device family.
+func ResolveDelivery(caps media.Renderer, source *media.Stream, cfg Config) DeliveryMode {
+	if cfg.Delivery == DeliveryServe {
+		return DeliverServe
+	}
 	if caps.SelfFetch && source.SelfFetchable() && caps.AcceptsContainer(source.ContentType) {
 		return DeliverPassthrough
 	}

--- a/internal/cast/core/resolve.go
+++ b/internal/cast/core/resolve.go
@@ -8,13 +8,21 @@ import (
 )
 
 // ResolveDelivery decides how the renderer receives the stream: pass-through
-// (the device fetches the source URL itself) when it both self-fetches AND
-// already accepts the source container, so there is nothing to rewrap; otherwise
-// castor serves a locally produced stream. It is decided purely from capability
-// data: a self-fetching renderer hands an accepted container straight to the
-// device and has the rest remuxed, while a push-only renderer always serves.
+// (the device fetches the source URL itself) only when all three hold, otherwise
+// castor serves a locally produced stream.
+//
+//   - the renderer self-fetches (a push-only one only plays what castor serves);
+//   - the source is self-fetchable, i.e. reachable from the URL alone: a
+//     pass-through carries none of the request headers castor captured, so a
+//     header-gated source must be pulled by castor and served (see
+//     media.Stream.SelfFetchable);
+//   - the renderer already accepts the source container, so there is nothing to
+//     rewrap.
+//
+// It is decided purely from data: capabilities on one side, the source on the
+// other, no I/O and no device family.
 func ResolveDelivery(caps media.Renderer, source *media.Stream) DeliveryMode {
-	if caps.SelfFetch && caps.AcceptsContainer(source.ContentType) {
+	if caps.SelfFetch && source.SelfFetchable() && caps.AcceptsContainer(source.ContentType) {
 		return DeliverPassthrough
 	}
 	return DeliverServe

--- a/internal/cast/ffmpeg/args.go
+++ b/internal/cast/ffmpeg/args.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/stupside/castor/internal/media"
 )
@@ -15,6 +16,45 @@ import (
 // uses a nil pointer for the same intent), named so callers set and test it
 // without repeating the bare "copy" literal.
 const CodecCopy = "copy"
+
+// NetworkSource is an upstream castor reads over the network: the URL plus
+// everything a fetch of it needs to succeed and behave. Castor has exactly two
+// network readers (the spool puller and the served remux) and both describe
+// their upstream with this one type, so the whole input side of their command
+// lines is assembled by networkInputArgs and cannot drift apart.
+type NetworkSource struct {
+	URL *url.URL
+
+	// Headers are the HTTP request headers ffmpeg sends when fetching URL
+	// (Referer, Origin, Cookie, User-Agent: what a proxied CDN gates on).
+	Headers http.Header
+
+	// ContentType is the source's container. It selects the container-specific
+	// input flags (see containerInputArgs) and whether the source is fetched as
+	// segments (see segmented).
+	ContentType string
+
+	// Live marks a genuinely live stream: it arrives at 1x and cannot be
+	// outrun, so it is read at wall-clock speed with no burst.
+	Live bool
+
+	// RWTimeout is how long a single upstream read may stall before ffmpeg
+	// gives up on it and reconnects.
+	RWTimeout time.Duration
+}
+
+// NewNetworkSource describes a resolved stream as an upstream to read. Both
+// readers build their source through it, so a pull and a remux of the same
+// stream fetch it identically.
+func NewNetworkSource(stream *media.Stream, rwTimeout time.Duration) NetworkSource {
+	return NetworkSource{
+		URL:         stream.URL,
+		Headers:     stream.Headers,
+		ContentType: stream.ContentType,
+		Live:        stream.Live,
+		RWTimeout:   rwTimeout,
+	}
+}
 
 // EncodeOptions is the full description of an encode invocation. Every choice
 // is explicit; nothing is inferred from globals or context. The planner
@@ -27,21 +67,9 @@ type EncodeOptions struct {
 	// which is what lets ffmpeg consume a still-growing stream.
 	PipeFormat string
 
-	// SourceURL is the network input, used when PipeFormat is empty.
-	SourceURL *url.URL
-
-	// SourceHeaders are HTTP headers ffmpeg sends when fetching SourceURL
-	// (Referer, User-Agent, Cookie, etc. — needed for HLS behind proxies).
-	SourceHeaders http.Header
-
-	// SourceContentType is the MIME type of SourceURL. It selects the
-	// container-specific input flags (see containerInputArgs). Only consulted
-	// for a network source (PipeFormat empty).
-	SourceContentType string
-
-	// RWTimeoutMicros is the upstream I/O timeout in microseconds, passed to
-	// ffmpeg's -rw_timeout for HTTP(S) input. Ignored for stdin input.
-	RWTimeoutMicros int64
+	// Source is the network input, read when PipeFormat is empty and ignored
+	// otherwise.
+	Source NetworkSource
 
 	// OutputFormat is ffmpeg's muxer name ("mpegts", "mp4", "hls"). "hls" writes
 	// a playlist plus rolling fMP4 segments into the process working directory
@@ -131,6 +159,71 @@ func containerInputArgs(contentType string) []string {
 	}
 }
 
+// pacing is how fast a reader consumes its input: an ffmpeg -readrate multiple
+// of realtime, plus how many seconds it may take at wire speed first. The zero
+// value is wire speed throughout.
+type pacing struct{ readrate, burst string }
+
+// The paces castor reads at. The first two are per source nature and shared by
+// both network readers: VOD bursts at wire speed then reads at 2x realtime, which
+// keeps a reader well ahead of 1x playback without pulling a whole movie in a
+// couple of minutes; live can't be outrun, and the same burst only asks a CDN for
+// segments that do not exist yet and trips its rate limiter.
+var (
+	pacingVOD  = pacing{readrate: "2.0", burst: "90"}
+	pacingLive = pacing{readrate: "1.0", burst: "0"}
+	// pacingHLSWindow is imposed by an output rather than a source: it feeds a
+	// deleting HLS window (see hlsOutputArgs) at exactly wall-clock speed, not the
+	// slight over-speed above, because the client consumes that window at 1x and
+	// anything faster rolls the next-needed segment off the back before it asks.
+	// The burst fills the window once so the device can prebuffer first.
+	pacingHLSWindow = pacing{readrate: "1.0", burst: strconv.Itoa(hlsWindowSeconds)}
+)
+
+// args renders the pacing as ffmpeg input flags, or nothing when unpaced.
+func (p pacing) args() []string {
+	if p.readrate == "" {
+		return nil
+	}
+	return []string{"-readrate", p.readrate, "-readrate_initial_burst", p.burst}
+}
+
+// pacing returns the read rate this source's nature calls for, for a reader that
+// paces at all (see segmented).
+func (s NetworkSource) pacing() pacing {
+	if s.Live {
+		return pacingLive
+	}
+	return pacingVOD
+}
+
+// segmented reports whether reading this source means many small segment
+// requests rather than one long GET, which is what decides whether a reader free
+// to run at wire speed should pace anyway: a two-hour HLS title read unpaced is
+// thousands of requests in a couple of minutes, and CDNs answer that with 429s.
+// One long GET of a single file (mp4/mkv/avi) is throttled by nothing.
+func (s NetworkSource) segmented() bool { return s.ContentType == media.HLS }
+
+// networkInputArgs renders the input side of a network read: the pacing, the
+// reconnect policy every upstream fetch castor makes shares, the request
+// headers, the container's input flags, and the URL.
+func networkInputArgs(src NetworkSource, pace pacing) []string {
+	args := pace.args()
+	args = append(args,
+		"-rw_timeout", strconv.FormatInt(src.RWTimeout.Microseconds(), 10),
+		"-reconnect", "1",
+		"-reconnect_streamed", "1",
+		// A minute of backoff paired with 429-as-reconnect lets a rate-limited
+		// CDN be waited out, instead of the HLS demuxer burning through segment
+		// numbers that all fail and keeping the IP tarpitted.
+		"-reconnect_delay_max", "60",
+		"-reconnect_on_http_error", "429",
+	)
+	args = append(args, media.HeaderArgs(src.Headers)...)
+	args = append(args, containerInputArgs(src.ContentType)...)
+	return append(args, "-i", src.URL.String())
+}
+
 // EncodeArgs assembles the encode command line. No "magic" flags: every
 // argument is either part of the standard input/output setup or comes
 // straight from a field in EncodeOptions. It enforces the one cross-field
@@ -166,36 +259,31 @@ func EncodeArgs(opts EncodeOptions) ([]string, error) {
 			// smear or skip) and overtakes the transcriber's commit frontier,
 			// after which every cue lookup misses and subtitles stop. It must
 			// not be exactly realtime either — see EncodeReadrate.
-			args = append(args,
-				"-readrate", EncodeReadrate,
-				"-readrate_initial_burst", strconv.Itoa(EncodeReadrateBurstSeconds),
-			)
+			args = append(args, pacing{
+				readrate: EncodeReadrate,
+				burst:    strconv.Itoa(EncodeReadrateBurstSeconds),
+			}.args()...)
 		}
 		args = append(args, "-f", opts.PipeFormat, "-i", "pipe:0")
 	} else {
-		// Serving a deleting HLS window (see hlsOutputArgs) requires realtime
-		// pacing: unpaced, ffmpeg copies a VOD file at wire speed and its
-		// delete_segments window rolls off the segments faster than the device
-		// plays them at 1x, so only the tail is ever fetchable. Read at wall-clock
-		// speed with an initial burst that fills the window once, so the device
-		// prebuffers and then stays in lockstep. A genuinely live source already
-		// arrives at 1x, so this neither helps nor hurts it. The single-file mp4
-		// remux is spooled from byte 0 by the replay server and must stay unpaced.
-		if opts.OutputFormat == hlsMuxer {
-			args = append(args,
-				"-readrate", hlsPaceReadrate,
-				"-readrate_initial_burst", strconv.Itoa(hlsWindowSeconds),
-			)
+		// This reader may run at wire speed, since its output is either
+		// replay-spooled from byte 0 or a rolling window, so it paces only where
+		// running fast would hurt:
+		//
+		//   - a deleting HLS output window (see hlsOutputArgs) must be produced at
+		//     exactly wall-clock speed, or the window rolls segments off faster than
+		//     the device plays them at 1x and only the tail is ever fetchable; its
+		//     burst fills the window once so the device can prebuffer first;
+		//   - a segmented source is read at the pace its nature calls for, since
+		//     wire speed against a segmented CDN is a request storm (see segmented).
+		var pace pacing
+		switch {
+		case opts.OutputFormat == hlsMuxer:
+			pace = pacingHLSWindow
+		case opts.Source.segmented():
+			pace = opts.Source.pacing()
 		}
-		args = append(args,
-			"-rw_timeout", strconv.FormatInt(opts.RWTimeoutMicros, 10),
-			"-reconnect", "1",
-			"-reconnect_streamed", "1",
-			"-reconnect_delay_max", "5",
-		)
-		args = append(args, media.HeaderArgs(opts.SourceHeaders)...)
-		args = append(args, containerInputArgs(opts.SourceContentType)...)
-		args = append(args, "-i", opts.SourceURL.String())
+		args = append(args, networkInputArgs(opts.Source, pace)...)
 	}
 
 	// Map the first video and first audio track explicitly. ffmpeg's default
@@ -319,13 +407,9 @@ const (
 	hlsSegmentSeconds = 4
 	// hlsListSize is how many segments the rolling playlist keeps on disk.
 	hlsListSize = 8
-	// hlsWindowSeconds is the on-disk window; it also sizes the realtime pacing
+	// hlsWindowSeconds is the on-disk window; it also sizes pacingHLSWindow's
 	// burst so the device can prebuffer one full window before pacing binds.
 	hlsWindowSeconds = hlsSegmentSeconds * hlsListSize
-	// hlsPaceReadrate reads the source at exactly wall-clock speed. Not the slight
-	// over-speed the pipe encode uses: the client consumes the deleting window at
-	// 1x, so any faster rolls the next-needed segment off the back before it asks.
-	hlsPaceReadrate = "1.0"
 )
 
 func hlsOutputArgs() []string {
@@ -341,21 +425,11 @@ func hlsOutputArgs() []string {
 	}
 }
 
-// Pull pacing per source nature. VOD bursts at wire speed then 2x
-// realtime. Live can't be outrun — the same burst trips rate limits.
-const (
-	pullReadrateVOD       = "2.0"
-	pullReadrateBurstVOD  = "90"
-	pullReadrateLive      = "1.0"
-	pullReadrateBurstLive = "0"
-)
-
 // PullOptions configures the single upstream reader's command line.
 type PullOptions struct {
-	SourceURL         *url.URL
-	SourceHeaders     http.Header
-	SourceContentType string // MIME type of SourceURL; selects container-specific input flags
-	RWTimeoutMicros   int64
+	// Source is the upstream to download, read exactly as the served remux
+	// reads its own (same reconnect policy, headers, container flags, pacing).
+	Source NetworkSource
 
 	// Verbose selects -loglevel verbose (playlist/segment URLs, connection
 	// lines) instead of the default warning level.
@@ -366,9 +440,6 @@ type PullOptions struct {
 	PCM bool
 	// PCMSampleRate is the audio sample rate for the PCM output.
 	PCMSampleRate int
-
-	// Live selects live pacing (see pullReadrate constants) instead of VOD.
-	Live bool
 }
 
 // PullArgs assembles the upstream download command line: a codec-copy remux
@@ -388,29 +459,12 @@ func PullArgs(opts PullOptions) []string {
 		logLevel = "verbose"
 	}
 
-	args := []string{
-		"-nostats",
-		"-loglevel", logLevel,
-		"-rw_timeout", strconv.FormatInt(opts.RWTimeoutMicros, 10),
-		"-reconnect", "1",
-		"-reconnect_streamed", "1",
-		// Treat HTTP 429 as a reconnect trigger so ffmpeg's exponential
-		// backoff (capped at 60 s) absorbs rate limiting instead of the
-		// HLS demuxer spinning through failed segment numbers at wire
-		// speed and keeping the IP tarpitted.
-		"-reconnect_delay_max", "60",
-		"-reconnect_on_http_error", "429",
-	}
+	args := []string{"-nostats", "-loglevel", logLevel}
 
-	readrate, burst := pullReadrateVOD, pullReadrateBurstVOD
-	if opts.Live {
-		readrate, burst = pullReadrateLive, pullReadrateBurstLive
-	}
-	args = append(args, "-readrate", readrate, "-readrate_initial_burst", burst)
-
-	args = append(args, media.HeaderArgs(opts.SourceHeaders)...)
-	args = append(args, containerInputArgs(opts.SourceContentType)...)
-	args = append(args, "-i", opts.SourceURL.String())
+	// The pull always paces, whatever the container: it buffers a whole title
+	// into a spool the encoder tails, so running further ahead than the source's
+	// own pace buys nothing and only spends the origin's patience.
+	args = append(args, networkInputArgs(opts.Source, opts.Source.pacing())...)
 
 	// Output 1: codec-copy remux to MPEG-TS on stdout → spool. mpegts is the
 	// right spool format because it is strictly append-only (no trailer or

--- a/internal/cast/ffmpeg/args_test.go
+++ b/internal/cast/ffmpeg/args_test.go
@@ -2,10 +2,12 @@ package ffmpeg
 
 import (
 	"context"
+	"net/http"
 	"net/url"
 	"slices"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stupside/castor/internal/media"
 )
@@ -307,11 +309,10 @@ func TestEncodeArgsHLSOutput(t *testing.T) {
 		t.Fatal(err)
 	}
 	args, err := EncodeArgs(EncodeOptions{
-		SourceURL:         src,
-		SourceContentType: media.MKV,
-		OutputFormat:      "hls",
-		AudioCodec:        "aac",
-		AudioBitrate:      "256k",
+		Source:       NetworkSource{URL: src, ContentType: media.MKV},
+		OutputFormat: "hls",
+		AudioCodec:   "aac",
+		AudioBitrate: "256k",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -354,24 +355,96 @@ func TestEncodeArgsHLSOutput(t *testing.T) {
 	}
 }
 
-// TestEncodeArgsMP4RemuxUnpaced pins the asymmetry: the single-file mp4 network
-// remux is fronted by the replay-from-zero server (spooled), so it must NOT be
-// paced (only the deleting HLS window needs realtime pacing).
+// TestEncodeArgsMP4RemuxUnpaced pins the asymmetry: a single-file network source
+// is one long GET, and its mp4 remux is fronted by the replay-from-zero server
+// (spooled), so it must NOT be paced: it should complete as fast as the link
+// allows.
 func TestEncodeArgsMP4RemuxUnpaced(t *testing.T) {
 	src, err := url.Parse("http://example.test/in.mkv")
 	if err != nil {
 		t.Fatal(err)
 	}
 	args, err := EncodeArgs(EncodeOptions{
-		SourceURL:         src,
-		SourceContentType: media.MKV,
-		OutputFormat:      "mp4",
-		AudioCodec:        "aac",
+		Source:       NetworkSource{URL: src, ContentType: media.MKV},
+		OutputFormat: "mp4",
+		AudioCodec:   "aac",
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if hasFlag(args, "-readrate") {
-		t.Error("the mp4 remux is replay-spooled from byte 0 and must not be paced")
+		t.Error("the mp4 remux of a single-file source is replay-spooled from byte 0 and must not be paced")
+	}
+}
+
+// TestNetworkReadersShareInputPolicy pins the invariant behind NetworkSource:
+// castor's two network readers open the same upstream with the same reconnect
+// policy, headers, container flags, and pacing.
+func TestNetworkReadersShareInputPolicy(t *testing.T) {
+	src, err := url.Parse("http://example.test/index.m3u8")
+	if err != nil {
+		t.Fatal(err)
+	}
+	source := NetworkSource{
+		URL:         src,
+		Headers:     http.Header{"Referer": {"https://player.example/"}},
+		ContentType: media.HLS,
+		RWTimeout:   30 * time.Second,
+	}
+
+	remux, err := EncodeArgs(EncodeOptions{Source: source, OutputFormat: "mp4", AudioCodec: "aac"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	pull := PullArgs(PullOptions{Source: source})
+
+	for _, flag := range []string{
+		"-rw_timeout", "-reconnect", "-reconnect_streamed",
+		"-reconnect_delay_max", "-reconnect_on_http_error",
+		"-headers", "-allowed_extensions", "-extension_picky",
+		"-readrate", "-readrate_initial_burst",
+	} {
+		if got, want := argValue(remux, flag), argValue(pull, flag); got != want {
+			t.Errorf("%s: remux = %q, pull = %q; both read the same upstream and must agree", flag, got, want)
+		}
+	}
+}
+
+// TestEncodeArgsHLSSourcePaced pins the other half of that rule: an HLS source is
+// fetched segment by segment from a rate-limiting CDN, so even the replay-spooled
+// mp4 remux paces its upstream read exactly like the puller does, rather than
+// pulling a whole movie as a segment burst and earning a 429.
+func TestEncodeArgsHLSSourcePaced(t *testing.T) {
+	src, err := url.Parse("http://example.test/index.m3u8")
+	if err != nil {
+		t.Fatal(err)
+	}
+	base := EncodeOptions{
+		Source:       NetworkSource{URL: src, ContentType: media.HLS},
+		OutputFormat: "mp4",
+		AudioCodec:   "aac",
+	}
+
+	args, err := EncodeArgs(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := argValue(args, "-readrate"); got != pacingVOD.readrate {
+		t.Errorf("VOD readrate = %q, want %q (ahead of 1x playback, but not a wire-speed storm)", got, pacingVOD.readrate)
+	}
+	if got := argValue(args, "-readrate_initial_burst"); got != pacingVOD.burst {
+		t.Errorf("VOD burst = %q, want %q", got, pacingVOD.burst)
+	}
+
+	base.Source.Live = true
+	args, err = EncodeArgs(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := argValue(args, "-readrate"); got != pacingLive.readrate {
+		t.Errorf("live readrate = %q, want %q (a live source cannot be outrun)", got, pacingLive.readrate)
+	}
+	if got := argValue(args, "-readrate_initial_burst"); got != pacingLive.burst {
+		t.Errorf("live burst = %q, want %q", got, pacingLive.burst)
 	}
 }

--- a/internal/cast/ffmpeg/probe.go
+++ b/internal/cast/ffmpeg/probe.go
@@ -5,27 +5,42 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/http"
 	"os/exec"
 	"strings"
 
 	"github.com/stupside/castor/internal/media"
 )
 
-// Probe runs ffprobe against input (a URL or a local file path) and returns the
-// per-track codec details as a media.ProbeInfo (the domain type). It is safe to
-// point at a still-growing local spool: ffprobe reads from the start, analyses
-// the leading packets, and returns. headers are the HTTP request headers for a
-// network input behind a proxy/CDN (Referer, Cookie, etc.); pass nil for a local
-// file.
-func Probe(ctx context.Context, ffprobePath, input string, headers http.Header) (media.ProbeInfo, error) {
+// ProbeFile probes a local file and returns its per-track codec details. It is
+// safe to point at a still-growing spool: ffprobe reads from the start, analyses
+// the leading packets, and returns.
+func ProbeFile(ctx context.Context, ffprobePath, path string) (media.ProbeInfo, error) {
+	return probe(ctx, ffprobePath, path, nil)
+}
+
+// ProbeSource probes an upstream over the network. It opens the source exactly
+// as the reader that follows it will (same request headers, same
+// container-specific input flags), so it cannot fail where the read would
+// succeed. That matters for a playlist whose segments are served under a
+// disguised extension: without the relaxed extension checks the probe reports an
+// unreadable stream while the remux plays it fine.
+func ProbeSource(ctx context.Context, ffprobePath string, src NetworkSource) (media.ProbeInfo, error) {
+	args := media.HeaderArgs(src.Headers)
+	args = append(args, containerInputArgs(src.ContentType)...)
+	return probe(ctx, ffprobePath, src.URL.String(), args)
+}
+
+// probe runs ffprobe against input and maps its JSON to the domain ProbeInfo.
+// inputArgs are the flags an input needs to be opened at all (headers, container
+// leniency); everything the decision layer reads is in the -show_entries list.
+func probe(ctx context.Context, ffprobePath, input string, inputArgs []string) (media.ProbeInfo, error) {
 	args := []string{
 		"-v", "error",
 		"-print_format", "json",
 		"-show_entries",
 		"stream=codec_type,codec_name,profile,height,pix_fmt,color_transfer,channels",
 	}
-	args = append(args, media.HeaderArgs(headers)...)
+	args = append(args, inputArgs...)
 	args = append(args, input)
 
 	out, err := exec.CommandContext(ctx, ffprobePath, args...).Output()

--- a/internal/cast/pipeline/engine.go
+++ b/internal/cast/pipeline/engine.go
@@ -114,9 +114,11 @@ func runRemux(ctx context.Context, cfg core.Config, plan core.Plan, dev device.D
 	// signed link: the probe can burn the token or a rate-limit slot and leave the
 	// remux ffmpeg with a 403/429. HLS (the common signed-link shape) normally
 	// passes through and never reaches here, but only while the receiver advertises
-	// HLS, so this is a known, accepted risk, not a guarantee. A failed probe
-	// leaves srcInfo zero, which core.ResolveAudio degrades to stereo AAC.
-	srcInfo, err := ffmpeg.Probe(ctx, cfg.Resolver.FFprobePath, source.URL.String(), source.Headers)
+	// HLS, so this is a known, accepted risk, not a guarantee. The probe reads the
+	// same headers and container flags the remux itself will use, so it fails only
+	// where the remux would; a failed probe leaves srcInfo zero, which
+	// core.ResolveAudio degrades to stereo AAC.
+	srcInfo, err := ffmpeg.ProbeSource(ctx, cfg.Resolver.FFprobePath, opts.Source)
 	if err != nil {
 		slog.WarnContext(ctx, "source probe failed; will re-encode audio to stereo AAC", "error", err)
 	}
@@ -231,7 +233,7 @@ func runSpooled(parentCtx context.Context, cfg core.Config, connect ConnectFunc,
 	// decide whether the source video can be stream-copied into MPEG-TS or must be
 	// re-encoded. A failed or partial probe leaves srcInfo zero, which CanCopyVideo
 	// rejects, i.e. it falls back to a transcode.
-	srcInfo, err := ffmpeg.Probe(ctx, cfg.Resolver.FFprobePath, sp.Path(), nil)
+	srcInfo, err := ffmpeg.ProbeFile(ctx, cfg.Resolver.FFprobePath, sp.Path())
 	if err != nil {
 		slog.WarnContext(ctx, "spool probe failed; will re-encode video", "error", err)
 	}

--- a/internal/cast/pipeline/engine.go
+++ b/internal/cast/pipeline/engine.go
@@ -24,6 +24,7 @@
 package pipeline
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"log/slog"
@@ -99,13 +100,14 @@ func passthrough(ctx context.Context, dev device.Device, source *media.Stream) e
 // can replay from 0; a segmented (HLS) remux is packaged into a directory the HLS
 // server fronts.
 func runRemux(ctx context.Context, cfg core.Config, plan core.Plan, dev device.Device, source *media.Stream, localIP string) error {
-	// The header keys are why a renderer that accepts the source container is
-	// being served one instead.
+	// The header keys, or a configured preference, are why a renderer that accepts
+	// the source container is being served one instead.
 	slog.InfoContext(ctx, "execution plan",
 		"delivery", "remux",
 		"output_content_type", plan.OutputContentType,
 		"source_content_type", source.ContentType,
 		"source_header_keys", slices.Sorted(maps.Keys(source.Headers)),
+		"configured_delivery", cmp.Or(cfg.Delivery, core.DeliveryAuto),
 	)
 
 	workDir, err := os.MkdirTemp("", "castor-")

--- a/internal/cast/pipeline/engine.go
+++ b/internal/cast/pipeline/engine.go
@@ -14,8 +14,10 @@
 //
 // Three compositions cover both of today's device families exactly:
 //   - pass-through: hand the device the source URL, it fetches the bytes itself;
-//   - network remux: a self-fetching renderer that rejects the source container,
-//     so a single ffmpeg reads the source URL and remuxes to a container it takes;
+//   - network remux: a self-fetching renderer that cannot be handed the source
+//     URL (it rejects the container, or the source only answers to the request
+//     headers castor holds and a renderer is handed none of them), so a single
+//     ffmpeg reads the source and remuxes to a container it takes;
 //   - read-once spool: a served renderer that never self-fetches, so one puller
 //     buffers the single-use source into a local spool the encoder reads from,
 //     with optional whisper burn-in. This is the concurrent-connect path.
@@ -25,8 +27,10 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 
 	"golang.org/x/sync/errgroup"
 
@@ -57,7 +61,8 @@ func Run(ctx context.Context, cfg core.Config, connect ConnectFunc, source *medi
 
 // runSelfFetch connects a smart renderer up front (its discovery is fast) and
 // then, per the plan its live capabilities produce, either hands it the source
-// URL (it accepts the container) or remuxes to a container it will take.
+// URL (the source needs nothing but the URL and the renderer accepts the
+// container) or reads the source itself and serves the renderer a remux.
 func runSelfFetch(ctx context.Context, cfg core.Config, connect ConnectFunc, source *media.Stream, localIP string) error {
 	dev, err := connect(ctx, cfg)
 	if err != nil {
@@ -87,12 +92,21 @@ func passthrough(ctx context.Context, dev device.Device, source *media.Stream) e
 }
 
 // runRemux is the single-ffmpeg served path for a self-fetching renderer that
-// rejects the source container: network input, video stream-copied, container
-// changed to the plan's output type. No whisper, no input spool. A single-file
-// remux is spooled by the replay server so the device can replay from 0; a
-// segmented (HLS) remux is packaged into a directory the HLS server fronts.
+// either rejects the source container or cannot be handed the source URL at all
+// (it only answers to the request headers castor captured): network input, video
+// stream-copied, container changed to the plan's output type. No whisper, no
+// input spool. A single-file remux is spooled by the replay server so the device
+// can replay from 0; a segmented (HLS) remux is packaged into a directory the HLS
+// server fronts.
 func runRemux(ctx context.Context, cfg core.Config, plan core.Plan, dev device.Device, source *media.Stream, localIP string) error {
-	slog.InfoContext(ctx, "execution plan", "delivery", "remux", "output_content_type", plan.OutputContentType)
+	// The header keys are why a renderer that accepts the source container is
+	// being served one instead.
+	slog.InfoContext(ctx, "execution plan",
+		"delivery", "remux",
+		"output_content_type", plan.OutputContentType,
+		"source_content_type", source.ContentType,
+		"source_header_keys", slices.Sorted(maps.Keys(source.Headers)),
+	)
 
 	workDir, err := os.MkdirTemp("", "castor-")
 	if err != nil {
@@ -112,12 +126,12 @@ func runRemux(ctx context.Context, cfg core.Config, plan core.Plan, dev device.D
 	// For the usual remux input (a static file in a container the device won't
 	// take, e.g. AVI) that is fine. It is NOT free for a short-lived or single-use
 	// signed link: the probe can burn the token or a rate-limit slot and leave the
-	// remux ffmpeg with a 403/429. HLS (the common signed-link shape) normally
-	// passes through and never reaches here, but only while the receiver advertises
-	// HLS, so this is a known, accepted risk, not a guarantee. The probe reads the
-	// same headers and container flags the remux itself will use, so it fails only
-	// where the remux would; a failed probe leaves srcInfo zero, which
-	// core.ResolveAudio degrades to stereo AAC.
+	// remux ffmpeg with a 403/429. An HLS source reaches here whenever it is
+	// header-gated (the renderer cannot be handed the URL), which is the common
+	// signed-link shape, so this is a known, accepted cost. It reads the same
+	// headers and container flags the remux itself will use, so it fails only where
+	// the remux would; a failed probe leaves srcInfo zero, which core.ResolveAudio
+	// degrades to stereo AAC.
 	srcInfo, err := ffmpeg.ProbeSource(ctx, cfg.Resolver.FFprobePath, opts.Source)
 	if err != nil {
 		slog.WarnContext(ctx, "source probe failed; will re-encode audio to stereo AAC", "error", err)

--- a/internal/cast/pipeline/engine_test.go
+++ b/internal/cast/pipeline/engine_test.go
@@ -146,7 +146,7 @@ func TestRunHeaderGatedSourceIsServed(t *testing.T) {
 		},
 		drain: true,
 	}
-	runServed(t, dev, device.TypeChromecast, source, ffmpegPath, ffprobePath)
+	runServed(t, dev, castConfig(device.TypeChromecast, ffmpegPath, ffprobePath), source)
 	assertServed(t, dev, media.MP4, source.URL.String())
 }
 
@@ -180,7 +180,7 @@ func TestRunServeHeaderGatedHLS(t *testing.T) {
 		drain: true,
 		tee:   served,
 	}
-	runServed(t, dev, device.TypeChromecast, source, ffmpegPath, ffprobePath)
+	runServed(t, dev, castConfig(device.TypeChromecast, ffmpegPath, ffprobePath), source)
 	assertServed(t, dev, media.MP4, source.URL.String())
 
 	if err := served.Close(); err != nil {
@@ -194,6 +194,33 @@ func TestRunServeHeaderGatedHLS(t *testing.T) {
 		t.Errorf("served stream = %q/%q, want h264/aac: the point of serving is that the renderer receives a well-formed stream",
 			info.VideoCodec, info.AudioCodec)
 	}
+}
+
+// TestRunConfiguredServeIsServed covers the operator's override reaching the
+// executor: the source needs no headers and the renderer takes its container, so
+// the rule alone would pass it through. Configured serve relays it instead, which
+// is the escape hatch for a source castor has no way to convict.
+func TestRunConfiguredServeIsServed(t *testing.T) {
+	ffmpegPath, ffprobePath := requireFFmpegTools(t)
+
+	origin := serveFixture(t, ffmpegPath)
+	source := origin.stream()
+
+	dev := &fakeDevice{
+		caps: media.Renderer{
+			SelfFetch:       true,
+			Containers:      []string{media.MP4}, // takes the source container
+			ServedContainer: media.MP4,
+			Audio:           []media.AudioSupport{{Codec: media.CodecAAC, MaxChannels: 2}},
+		},
+		drain: true,
+	}
+
+	cfg := castConfig(device.TypeChromecast, ffmpegPath, ffprobePath)
+	cfg.Delivery = core.DeliveryServe
+
+	runServed(t, dev, cfg, source)
+	assertServed(t, dev, media.MP4, source.URL.String())
 }
 
 // TestRunServeRemux is the network-remux branch: a self-fetching renderer that
@@ -217,7 +244,7 @@ func TestRunServeRemux(t *testing.T) {
 		},
 		drain: true,
 	}
-	runServed(t, dev, device.TypeChromecast, source, ffmpegPath, ffprobePath)
+	runServed(t, dev, castConfig(device.TypeChromecast, ffmpegPath, ffprobePath), source)
 	assertServed(t, dev, media.MP4, source.URL.String())
 }
 
@@ -239,7 +266,7 @@ func TestRunServeSpool(t *testing.T) {
 		},
 		drain: true,
 	}
-	runServed(t, dev, device.TypeDLNA, source, ffmpegPath, ffprobePath)
+	runServed(t, dev, castConfig(device.TypeDLNA, ffmpegPath, ffprobePath), source)
 	assertServed(t, dev, mpegtsContentType, source.URL.String())
 }
 
@@ -266,11 +293,7 @@ func TestRunServeHLS(t *testing.T) {
 			Audio:           []media.AudioSupport{{Codec: media.CodecAAC, MaxChannels: 2}},
 		},
 	}
-	cfg := core.Config{
-		Device:    core.DeviceConfig{Type: device.TypeChromecast}, // any self-fetch type
-		Transcode: core.TranscodeConfig{FFmpegPath: ffmpegPath, RWTimeout: 30 * time.Second},
-		Resolver:  resolve.Config{FFprobePath: ffprobePath, MaxHeight: 1080},
-	}
+	cfg := castConfig(device.TypeChromecast, ffmpegPath, ffprobePath) // any self-fetch type
 
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
@@ -310,18 +333,24 @@ func TestRunServeHLS(t *testing.T) {
 	}
 }
 
-// runServed drives Run for a served plan under a bounded context (a wedged
-// ffmpeg fails the test instead of hanging the suite) and fails on any error.
-func runServed(t *testing.T, dev *fakeDevice, deviceType device.Type, source *media.Stream, ffmpegPath, ffprobePath string) {
-	t.Helper()
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
-	defer cancel()
-
-	cfg := core.Config{
+// castConfig is the configuration a served-path test runs on: the device family
+// (which fixes the connect timing) plus the real ffmpeg tools. A test that needs
+// to vary an axis takes this and edits the field it cares about.
+func castConfig(deviceType device.Type, ffmpegPath, ffprobePath string) core.Config {
+	return core.Config{
 		Device:    core.DeviceConfig{Type: deviceType},
 		Transcode: core.TranscodeConfig{FFmpegPath: ffmpegPath, RWTimeout: 30 * time.Second},
 		Resolver:  resolve.Config{FFprobePath: ffprobePath, MaxHeight: 1080},
 	}
+}
+
+// runServed drives Run for a served plan under a bounded context (a wedged
+// ffmpeg fails the test instead of hanging the suite) and fails on any error.
+func runServed(t *testing.T, dev *fakeDevice, cfg core.Config, source *media.Stream) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
 	if err := Run(ctx, cfg, connectTo(dev), source, "127.0.0.1"); err != nil {
 		t.Fatalf("Run served: %v", err)
 	}

--- a/internal/cast/pipeline/engine_test.go
+++ b/internal/cast/pipeline/engine_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"slices"
@@ -16,6 +17,7 @@ import (
 	"time"
 
 	"github.com/stupside/castor/internal/cast/core"
+	"github.com/stupside/castor/internal/cast/ffmpeg"
 	"github.com/stupside/castor/internal/device"
 	"github.com/stupside/castor/internal/media"
 	"github.com/stupside/castor/internal/source/resolve"
@@ -29,6 +31,9 @@ import (
 type fakeDevice struct {
 	caps  media.Renderer
 	drain bool
+	// tee, when set, receives the served bytes as they are drained, so a test can
+	// inspect what the renderer was actually handed.
+	tee io.Writer
 
 	mu    sync.Mutex
 	plays []playCall
@@ -62,7 +67,11 @@ func (d *fakeDevice) Play(ctx context.Context, streamURL *url.URL, contentType s
 		return err
 	}
 	defer resp.Body.Close()
-	_, err = io.Copy(io.Discard, resp.Body)
+	var sink io.Writer = io.Discard
+	if d.tee != nil {
+		sink = d.tee
+	}
+	_, err = io.Copy(sink, resp.Body)
 	return err
 }
 
@@ -109,6 +118,81 @@ func TestRunPassthrough(t *testing.T) {
 	}
 	if plays[0].contentType != media.MP4 {
 		t.Errorf("Play content type = %q, want %q (the source's own type)", plays[0].contentType, media.MP4)
+	}
+}
+
+// TestRunHeaderGatedSourceIsServed is the pass-through guard: the renderer
+// self-fetches AND accepts the source container, but the source only ever
+// answered to the request headers castor captured. Handing such a URL to the
+// renderer strips those headers and the device silently idles, so Run must serve
+// the remux instead and never point the device at the source URL.
+func TestRunHeaderGatedSourceIsServed(t *testing.T) {
+	ffmpegPath, ffprobePath := requireFFmpegTools(t)
+
+	origin := serveFixture(t, ffmpegPath)
+	source := origin.stream()
+	source.Headers = http.Header{
+		"Referer": {"https://player.example/"},
+		"Origin":  {"https://player.example"},
+	}
+
+	// Accepts mp4, the source's own container: only the headers force the serve.
+	dev := &fakeDevice{
+		caps: media.Renderer{
+			SelfFetch:       true,
+			Containers:      []string{media.MP4},
+			ServedContainer: media.MP4,
+			Audio:           []media.AudioSupport{{Codec: media.CodecAAC, MaxChannels: 2}},
+		},
+		drain: true,
+	}
+	runServed(t, dev, device.TypeChromecast, source, ffmpegPath, ffprobePath)
+	assertServed(t, dev, media.MP4, source.URL.String())
+}
+
+// TestRunServeHeaderGatedHLS is the embed-source shape end to end: HLS that is
+// header-gated AND serves its MPEG-TS segments under a .jpg extension. A renderer
+// handed that playlist fetches without the headers and rejects the mislabelled
+// segments; castor reads it fine, so the cast must come out as a served remux, a
+// local mp4 URL and never the source.
+func TestRunServeHeaderGatedHLS(t *testing.T) {
+	ffmpegPath, ffprobePath := requireFFmpegTools(t)
+
+	origin := serveHLSFixture(t, ffmpegPath)
+	source := origin.stream()
+	source.Headers = http.Header{"Referer": {"https://player.example/"}}
+
+	// Capture what the renderer is handed, to check it decodes.
+	servedPath := filepath.Join(t.TempDir(), "served.mp4")
+	served, err := os.Create(servedPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer served.Close()
+
+	dev := &fakeDevice{
+		caps: media.Renderer{
+			SelfFetch:       true,
+			Containers:      []string{media.HLS, media.MP4}, // takes the source container
+			ServedContainer: media.MP4,
+			Audio:           []media.AudioSupport{{Codec: media.CodecAAC, MaxChannels: 2}},
+		},
+		drain: true,
+		tee:   served,
+	}
+	runServed(t, dev, device.TypeChromecast, source, ffmpegPath, ffprobePath)
+	assertServed(t, dev, media.MP4, source.URL.String())
+
+	if err := served.Close(); err != nil {
+		t.Fatal(err)
+	}
+	info, err := ffmpeg.ProbeFile(context.Background(), ffprobePath, servedPath)
+	if err != nil {
+		t.Fatalf("probing what the renderer was served: %v", err)
+	}
+	if info.VideoCodec != media.CodecH264 || info.AudioCodec != media.CodecAAC {
+		t.Errorf("served stream = %q/%q, want h264/aac: the point of serving is that the renderer receives a well-formed stream",
+			info.VideoCodec, info.AudioCodec)
 	}
 }
 
@@ -259,15 +343,19 @@ func assertServed(t *testing.T, dev *fakeDevice, wantCT, sourceURL string) {
 	}
 }
 
-// fixtureOrigin is a local HTTP origin serving a generated media file, standing
-// in for the upstream a real cast pulls from.
-type fixtureOrigin struct{ server *httptest.Server }
+// fixtureOrigin is a local HTTP origin serving generated media, standing in for
+// the upstream a real cast pulls from: path is what the cast points at and
+// contentType the container it resolved to.
+type fixtureOrigin struct {
+	server      *httptest.Server
+	path        string
+	contentType string
+}
 
-// stream is the media.Stream a cast resolves to for this origin. The ".mp4" path
-// only shapes the URL; the handler serves the fixture regardless.
+// stream is the media.Stream a cast resolves to for this origin.
 func (o fixtureOrigin) stream() *media.Stream {
-	u, _ := url.Parse(o.server.URL + "/movie.mp4")
-	return &media.Stream{URL: u, ContentType: media.MP4}
+	u, _ := url.Parse(o.server.URL + o.path)
+	return &media.Stream{URL: u, ContentType: o.contentType}
 }
 
 // serveFixture generates a one-second H.264/AAC mp4 and serves it over local
@@ -295,7 +383,38 @@ func serveFixture(t *testing.T, ffmpegPath string) fixtureOrigin {
 		http.ServeFile(w, r, path)
 	}))
 	t.Cleanup(server.Close)
-	return fixtureOrigin{server: server}
+	return fixtureOrigin{server: server, path: "/movie.mp4", contentType: media.MP4}
+}
+
+// serveHLSFixture generates a short HLS stream whose MPEG-TS segments are written
+// under a .jpg extension and serves the directory over local HTTP, which labels
+// them image/jpeg from that extension. That is the disguise embed CDNs use:
+// ffmpeg reads it (castor relaxes the extension checks for every HLS input),
+// while a Cast receiver handed the same playlist rejects the segments.
+func serveHLSFixture(t *testing.T, ffmpegPath string) fixtureOrigin {
+	t.Helper()
+	dir := t.TempDir()
+	args := []string{
+		"-hide_banner", "-loglevel", "error", "-y",
+		"-f", "lavfi", "-i", "testsrc=size=320x240:rate=15:duration=2",
+		"-f", "lavfi", "-i", "sine=frequency=440:duration=2",
+		"-c:v", "libx264", "-pix_fmt", "yuv420p", "-profile:v", "baseline",
+		"-c:a", "aac", "-ac", "2", "-shortest",
+		"-f", "hls",
+		"-hls_time", "1",
+		"-hls_list_size", "0",
+		"-hls_segment_filename", filepath.Join(dir, "seg_%03d.jpg"),
+		filepath.Join(dir, "index.m3u8"),
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	if out, err := exec.CommandContext(ctx, ffmpegPath, args...).CombinedOutput(); err != nil {
+		t.Fatalf("generating HLS fixture: %v\n%s", err, out)
+	}
+
+	server := httptest.NewServer(http.FileServer(http.Dir(dir)))
+	t.Cleanup(server.Close)
+	return fixtureOrigin{server: server, path: "/index.m3u8", contentType: media.HLS}
 }
 
 // requireFFmpegTools returns the ffmpeg and ffprobe paths, or skips: the served

--- a/internal/cast/pipeline/pull.go
+++ b/internal/cast/pipeline/pull.go
@@ -41,14 +41,10 @@ type pull struct {
 // wantPCM flag (driven by the plan's subtitle mode) changes what it produces.
 func startPull(ctx context.Context, cfg core.TranscodeConfig, resolved *media.Stream, sp *spool.Spool, wantPCM bool) (*pull, error) {
 	args := ffmpeg.PullArgs(ffmpeg.PullOptions{
-		SourceURL:         resolved.URL,
-		SourceHeaders:     resolved.Headers,
-		SourceContentType: resolved.ContentType,
-		RWTimeoutMicros:   cfg.RWTimeout.Microseconds(),
-		Verbose:           slog.Default().Enabled(ctx, slog.LevelDebug),
-		PCM:               wantPCM,
-		PCMSampleRate:     whisper.SampleRate,
-		Live:              resolved.Live,
+		Source:        ffmpeg.NewNetworkSource(resolved, cfg.RWTimeout),
+		Verbose:       slog.Default().Enabled(ctx, slog.LevelDebug),
+		PCM:           wantPCM,
+		PCMSampleRate: whisper.SampleRate,
 	})
 
 	var opts []ffmpeg.StartOption

--- a/internal/cast/pipeline/transcode.go
+++ b/internal/cast/pipeline/transcode.go
@@ -31,13 +31,11 @@ func spoolEncodeOptions(maxHeight int) ffmpeg.EncodeOptions {
 // stream-copied (the renderer decodes the source codec, only the container
 // changes). muxer is the ffmpeg muxer for the plan's output container, derived
 // from the renderer's declared ServedContainer. Audio is filled by
-// core.ResolveAudio afterward against a source probe.
+// core.ResolveAudio afterward against a probe of the same source description, so
+// the probe and the remux open the upstream identically.
 func remuxNetworkOptions(source *media.Stream, rwTimeout time.Duration, muxer string) ffmpeg.EncodeOptions {
 	return ffmpeg.EncodeOptions{
-		OutputFormat:      muxer,
-		SourceURL:         source.URL,
-		SourceHeaders:     source.Headers,
-		SourceContentType: source.ContentType,
-		RWTimeoutMicros:   rwTimeout.Microseconds(),
+		OutputFormat: muxer,
+		Source:       ffmpeg.NewNetworkSource(source, rwTimeout),
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,6 +17,7 @@ import (
 
 type Config struct {
 	Device    DeviceConfig          `yaml:"device" validate:"required"`
+	Cast      CastConfig            `yaml:"cast"`
 	Network   cast.NetworkConfig    `yaml:"network" validate:"required"`
 	Browser   extract.BrowserConfig `yaml:"browser" validate:"required"`
 	Capture   extract.CaptureConfig `yaml:"capture" validate:"required"`
@@ -33,6 +34,20 @@ type Config struct {
 // intentionally not marked required here.
 type TMDB struct {
 	APIKey string `yaml:"api_key"`
+}
+
+// CastConfig is the cast-behaviour section: the decisions castor cannot infer
+// and so leaves to the operator. It holds exactly one axis today, and the bar for
+// a second is high — every other decision the pipeline makes is derived from a
+// probe or from advertised capabilities, where a knob would bury a bug rather
+// than fix it.
+type CastConfig struct {
+	// Delivery forces castor to relay the stream ("serve") instead of deciding
+	// per source ("auto", the default). Set it for a source that a renderer
+	// refuses even though nothing about it looks unfetchable, e.g. an HLS
+	// playlist whose segments are served under a disguised extension. It costs
+	// this machine's bandwidth and CPU on every cast, which is why it is opt-in.
+	Delivery core.DeliveryPreference `yaml:"delivery" validate:"omitempty,oneof=auto serve"`
 }
 
 // DeviceConfig is the composition-root device section: the generic cast target
@@ -65,7 +80,9 @@ func (d DeviceConfig) resolve() device.Config {
 	return cfg
 }
 
-func (c *Config) Cast() cast.Config {
+// Playback assembles the configuration a cast runs on, collapsing this root's
+// sections into the domain types the cast layer consumes.
+func (c *Config) Playback() cast.Config {
 	return cast.Config{
 		Config: core.Config{
 			Device:    c.Device.resolve(),
@@ -73,6 +90,7 @@ func (c *Config) Cast() cast.Config {
 			Transcode: c.Transcode,
 			Resolver:  c.Resolver,
 			Whisper:   c.Whisper,
+			Delivery:  c.Cast.Delivery,
 		},
 	}
 }

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/stupside/castor/internal/cast/core"
 )
 
 func TestLoadMissingFileWithEnvVars(t *testing.T) {
@@ -104,8 +106,65 @@ func TestLoadHostPinsDeviceWithoutName(t *testing.T) {
 	if cfg.Device.Host != "192.168.0.3" {
 		t.Errorf("device.host = %q, want 192.168.0.3", cfg.Device.Host)
 	}
-	if got := cfg.Cast().Device.Address; got != "192.168.0.3" {
+	if got := cfg.Playback().Device.Address; got != "192.168.0.3" {
 		t.Errorf("host should resolve onto device.Config.Address, got %q", got)
+	}
+}
+
+// TestLoadCastDelivery covers the one cast decision the operator owns, from both
+// layers that matter for it: the file, and the environment, which is the reason
+// it is a config key rather than a CLI flag (CASTOR_CAST__DELIVERY=serve makes it
+// a one-off, and works in a container where a flag does not).
+func TestLoadCastDelivery(t *testing.T) {
+	dir := t.TempDir()
+	base := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(base, []byte("device:\n  name: tv\n  type: chromecast\ncast:\n  delivery: serve\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := cfg.Playback().Delivery; got != core.DeliveryServe {
+		t.Errorf("cast.delivery should reach the cast config, got %q", got)
+	}
+
+	// Unset is auto: a cast nobody configured is decided from capabilities and
+	// the source alone.
+	plain := filepath.Join(dir, "plain.yaml")
+	if err := os.WriteFile(plain, []byte("device:\n  name: tv\n  type: chromecast\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err = Load(plain)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := cfg.Playback().Delivery; got == core.DeliveryServe {
+		t.Errorf("an unset cast.delivery must not force serving, got %q", got)
+	}
+
+	t.Setenv("CASTOR_CAST__DELIVERY", "serve")
+	cfg, err = Load(plain)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := cfg.Playback().Delivery; got != core.DeliveryServe {
+		t.Errorf("CASTOR_CAST__DELIVERY should reach the cast config, got %q", got)
+	}
+}
+
+// TestLoadCastDeliveryRejectsUnknownMode is what the enum buys over a bool: a
+// typo fails at load with a validation error instead of silently meaning auto.
+func TestLoadCastDeliveryRejectsUnknownMode(t *testing.T) {
+	dir := t.TempDir()
+	base := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(base, []byte("device:\n  name: tv\n  type: chromecast\ncast:\n  delivery: relay\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := Load(base); err == nil {
+		t.Fatal("an unknown cast.delivery mode should fail validation")
 	}
 }
 

--- a/internal/media/media.go
+++ b/internal/media/media.go
@@ -44,6 +44,18 @@ type Stream struct {
 	Live        bool
 }
 
+// SelfFetchable reports whether a renderer handed nothing but this URL can pull
+// the bytes itself. A pass-through gives the device the URL alone: none of the
+// request headers castor captured while extracting (Referer, Origin, Cookie,
+// User-Agent) travel with it, and castor cannot know which of them the origin
+// gates on. A URL castor itself only ever fetched with headers is therefore not
+// proven fetchable without them, and handing it to a renderer fails where castor
+// succeeds. It fails silently, too: the device accepts the load and then sits
+// idle. Such a source is served locally instead, castor pulling upstream with
+// the headers it holds and giving the renderer a LAN URL. A header-free source
+// (the direct URL a user casts by hand) is self-sufficient and passes through.
+func (s *Stream) SelfFetchable() bool { return len(s.Headers) == 0 }
+
 // StreamInfo holds metadata returned by ffprobe for a stream.
 type StreamInfo struct {
 	BitRate     int64

--- a/internal/media/media_test.go
+++ b/internal/media/media_test.go
@@ -48,6 +48,27 @@ func TestStreamInfoPlayable(t *testing.T) {
 	}
 }
 
+func TestStreamSelfFetchable(t *testing.T) {
+	cases := []struct {
+		name    string
+		headers http.Header
+		want    bool
+	}{
+		{"no headers: the URL is all a renderer needs", nil, true},
+		{"empty header set is still self-sufficient", http.Header{}, true},
+		{"header-gated: a renderer is handed none of these", http.Header{"Referer": {"https://player.example/"}}, false},
+		{"any captured header counts", http.Header{"User-Agent": {"x"}}, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			s := &Stream{Headers: c.headers}
+			if got := s.SelfFetchable(); got != c.want {
+				t.Errorf("SelfFetchable() = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
 func TestNormalizeStreamHeaders(t *testing.T) {
 	cases := []struct {
 		name string


### PR DESCRIPTION
Pass-through was decided from the renderer alone, so a self-fetching device got the source URL even when castor could only fetch it with captured headers (Referer/Origin/Cookie). Chromecast accepts the load, fetches without them, and sits on the idle Cast icon while the CLI reports success.

Pass-through now also requires the source to be reachable from its URL alone. Header-gated sources are pulled by castor and served on the LAN, which also covers playlists whose segments are disguised (`.jpg`/`image/jpeg`): the receiver only ever sees a clean local remux. `castor cast url` of a public stream still passes through.

For the remaining case, a source that needs no headers and is refused anyway, `cast.delivery: serve` forces the relay. It is a config key rather than a flag so `CASTOR_CAST__DELIVERY=serve` works as a one-off and in a container.

Along the way, the two network readers were unified: the remux lacked the puller's 429 backoff and segment pacing, and probed HLS without the extension leniency its own read uses.

Not validated on real Chromecast hardware. The served path (`ServedContainer: MP4` → replay server) already existed but becomes the common one for extracted casts.

Closes #53