### PR TITLE
fix(ffmpeg): add aac_adtstoasc when copying AAC into MP4 remux

### DIFF
--- a/internal/cast/ffmpeg/args.go
+++ b/internal/cast/ffmpeg/args.go
@@ -256,6 +256,20 @@ func (s NetworkSource) audioMap() string {
 	return "0:a:0"
 }
 
+// needsAACADTSToASC reports whether stream-copied AAC must pass through the
+// aac_adtstoasc bitstream filter before muxing to MP4. HLS (and the MPEG-TS
+// spool read from pipe) carry AAC in ADTS framing; MP4 expects an
+// AudioSpecificConfig, and ffmpeg rejects the copy without this filter.
+func needsAACADTSToASC(opts EncodeOptions) bool {
+	if opts.AudioCodec != CodecCopy || opts.OutputFormat != "mp4" {
+		return false
+	}
+	if opts.PipeFormat == "mpegts" {
+		return true
+	}
+	return opts.Source.segmented()
+}
+
 // EncodeArgs assembles the encode command line. No "magic" flags: every
 // argument is either part of the standard input/output setup or comes
 // straight from a field in EncodeOptions. It enforces the one cross-field
@@ -375,6 +389,9 @@ func EncodeArgs(opts EncodeOptions) ([]string, error) {
 	}
 
 	args = append(args, "-c:a", opts.AudioCodec)
+	if opts.AudioCodec == CodecCopy && needsAACADTSToASC(opts) {
+		args = append(args, "-bsf:a", "aac_adtstoasc")
+	}
 	if opts.AudioCodec != CodecCopy {
 		if opts.AudioSampleRate > 0 {
 			args = append(args, "-ar", strconv.Itoa(opts.AudioSampleRate))

--- a/internal/cast/ffmpeg/args_test.go
+++ b/internal/cast/ffmpeg/args_test.go
@@ -377,6 +377,63 @@ func TestEncodeArgsMP4RemuxUnpaced(t *testing.T) {
 	}
 }
 
+// TestEncodeArgsMP4RemuxHLSCopyUsesADTSToASC pins the bitstream filter that
+// lets AAC stream-copied from MPEG-TS HLS segments mux into fragmented MP4.
+// Without it ffmpeg reports "Malformed AAC bitstream detected" and the served
+// remux dies before the renderer receives playable bytes.
+func TestEncodeArgsMP4RemuxHLSCopyUsesADTSToASC(t *testing.T) {
+	src, err := url.Parse("http://example.test/index.m3u8")
+	if err != nil {
+		t.Fatal(err)
+	}
+	args, err := EncodeArgs(EncodeOptions{
+		Source:       NetworkSource{URL: src, ContentType: media.HLS},
+		OutputFormat: "mp4",
+		AudioCodec:   CodecCopy,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := argValue(args, "-c:a"); got != CodecCopy {
+		t.Fatalf("-c:a = %q, want copy", got)
+	}
+	if got := argValue(args, "-bsf:a"); got != "aac_adtstoasc" {
+		t.Errorf("-bsf:a = %q, want aac_adtstoasc", got)
+	}
+}
+
+func TestEncodeArgsMP4RemuxHLSCopyADTSToASCNotForMPEGTS(t *testing.T) {
+	src, err := url.Parse("http://example.test/index.m3u8")
+	if err != nil {
+		t.Fatal(err)
+	}
+	args, err := EncodeArgs(EncodeOptions{
+		Source:       NetworkSource{URL: src, ContentType: media.HLS},
+		OutputFormat: "mpegts",
+		AudioCodec:   CodecCopy,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hasFlag(args, "-bsf:a") {
+		t.Error("mpegts output must not set -bsf:a aac_adtstoasc")
+	}
+}
+
+func TestEncodeArgsMP4RemuxSpoolCopyUsesADTSToASC(t *testing.T) {
+	args, err := EncodeArgs(EncodeOptions{
+		PipeFormat:   "mpegts",
+		OutputFormat: "mp4",
+		AudioCodec:   CodecCopy,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := argValue(args, "-bsf:a"); got != "aac_adtstoasc" {
+		t.Errorf("-bsf:a = %q, want aac_adtstoasc for mpegts pipe into mp4", got)
+	}
+}
+
 // TestDemuxedSourceIsTwoInputs covers a program whose renditions live at
 // separate URLs: both must be opened on the same terms, and the audio map must
 // follow the audio to the second input. Mapping 0:a:0 there is the failure this


### PR DESCRIPTION
## Summary
- When remuxing HLS (or MPEG-TS spool) to fragmented MP4 with `-c:a copy`, append `-bsf:a aac_adtstoasc` so ADTS-framed AAC muxes correctly.
- Without this filter, ffmpeg fails with `Malformed AAC bitstream detected: use the audio bitstream filter 'aac_adtstoasc'` and the Chromecast relay serves a truncated/unplayable stream.

Fixes #56

## Test plan
- [x] `go test ./internal/cast/ffmpeg/...`
- [ ] Manual: `castor cast movie <id>` against a header-gated HLS source on a Chromecast (remux delivery path)


Made with [Cursor](https://cursor.com)